### PR TITLE
fix: package friday CLI entrypoints through module wrappers

### DIFF
--- a/friday/__init__.py
+++ b/friday/__init__.py
@@ -1,1 +1,9 @@
 # Friday MCP Server Package
+
+import os
+import sys
+
+# Ensure project root is in sys.path so top-level modules (server, agent_friday) are importable
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)

--- a/friday/_entry.py
+++ b/friday/_entry.py
@@ -1,0 +1,12 @@
+"""Entry point wrappers — ensures project root is in sys.path before importing top-level modules."""
+import friday  # noqa: F401 — triggers sys.path patch in friday/__init__.py
+
+
+def run_server():
+    from server import main
+    main()
+
+
+def run_voice():
+    from agent_friday import dev
+    dev()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ dependencies = [
 ]
 
 [project.scripts]
-friday = "server:main"
-friday_voice = "agent_friday:dev" # Points to the wrapper
+friday = "friday._entry:run_server"
+friday_voice = "friday._entry:run_voice" # Points to the wrapper
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["server.py"]
+include = ["server.py", "agent_friday.py", "friday"]


### PR DESCRIPTION
## Summary
- route `friday` and `friday_voice` script entrypoints through `friday._entry` wrappers instead of top-level modules
- ensure the wheel includes `friday`, `server.py`, and `agent_friday.py` so installed CLI commands resolve imports correctly
- keep runtime compatibility by inserting project root into `sys.path` from `friday.__init__`

## Test plan
- [x] `uv run python -c "import friday; from friday._entry import run_server, run_voice; print('ok')"`
- [x] `uv run python -c "import server, friday._entry; print('server_entry_ok')"`
- [x] `uv run python -c "import agent_friday, friday._entry; print('voice_entry_ok')"`
- [x] `uv build`

Made with [Cursor](https://cursor.com)