### PR TITLE
feat: full tool suite, Ollama LLM, and infra fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,16 @@ SUPABASE_URL=https://your-project-id.supabase.co/rest/v1
 SUPABASE_API_KEY=your-supabase-api-key
 
 GOOGLE_API_KEY=you-google-api-key (from https://aistudio.google.com/projects)
+
+# ── Ollama (local LLM — no API key needed) ────────────────────────────────────
+# To switch to Ollama: set LLM_PROVIDER = "ollama" in agent_friday.py
+#
+# 1. Install Ollama: https://ollama.com/download
+# 2. Pull a model:   ollama pull llama3.2
+# 3. Ollama starts automatically at http://localhost:11434
+#
+# WSL users: leave OLLAMA_BASE_URL as localhost — the agent auto-resolves
+# the Windows host IP at runtime.
+#
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_MODEL=llama3.2

--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,13 @@ poetry.toml
 # LSP config files
 pyrightconfig.json
 
+# Local scratch/test artifacts
+.repl_input.txt
+.repl_out.txt
+.mcp_server.log
+agent.log
+agent.err.log
+mcp.log
+mcp.err.log
+
 # End of https://www.toptal.com/developers/gitignore/api/python

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,74 @@
+# FRIDAY — Tool Calling, Voice I/O, and Streaming TTS
+
+End-to-end upgrade of the FRIDAY voice agent: the model now calls MCP tools, speaks over Windows SAPI, accepts mic input via Whisper STT, and — new — streams TTS sentence-by-sentence so the user hears the first reply ~3-5s after asking instead of waiting 15-60s.
+
+## What's new
+
+### Tool calling (`145c66f`, `82fb15d`)
+- `friday_mcp.py` — MCP tool bridge that discovers tools from the running fastmcp server, filters by allowlist, and exposes them as LiveKit `RawFunctionTool` objects.
+- `_chat_with_tools` in `agent_friday.py` — drives a tool-calling loop: streams text + tool-call deltas, dispatches tool calls through the MCP client, appends `FunctionCall`/`FunctionCallOutput` items to the chat context, re-invokes `llm.chat()`. Capped at 4 iterations.
+- `FRIDAY_TOOLS` env var — CSV allowlist (default: 6 demo-critical tools to keep prefill ~60s on CPU). `FRIDAY_TOOLS=*` exposes all 18.
+- Tool result formatting via `structured_content` with single-key `"result"` envelope unwrap — clean JSON, no ugly `Output(result=...)` dataclass repr.
+
+### Text REPL mode (`5a227f8`, `6b7e6a3`)
+- New `repl` subcommand bypasses LiveKit's console loop for pure text Ollama chat. Instant greeting, no mic/speaker init.
+- Fixed Ollama timeout storms — 600s httpx read timeout + `APIConnectOptions(timeout=600.0)` — 7B models on CPU need it.
+
+### Voice mode (`1cab2a3`)
+- New `voice` subcommand — text-in, voice-out via a persistent Windows SAPI PowerShell daemon (amortized ~5s .NET JIT, then each utterance is one stdin line).
+- Zero cloud keys required for audio.
+
+### Full voice mode (`c1b5555`, `85b5058`, `dff3edf`)
+- New `fullvoice` subcommand — mic → STT → LLM → TTS → speaker.
+- `friday_stt.py` — faster-whisper `tiny.en` (int8 CPU, ~75MB), cached across turns. Two-Enter PTT gate. Silence/noise early-exit avoids feeding empty audio to Whisper.
+
+### Prewarm & tool-call reliability (`c6404f7`)
+- `_prewarm_llm` — primes Ollama's KV prefix cache with system prompt + tool schemas so the first real turn reuses ~2000-2500 tokens of prefill. Drains the stream to completion (early break caused cache-commit issues on Ollama's side).
+- Ran in parallel with TTS greeting in voice mode, serial in REPL.
+- Default model bumped to `qwen2.5:7b-instruct` — `llama3.2:1b` emits tool calls as free text (broken on Ollama's OpenAI-compat layer).
+- Documented `get_current_time` in `SYSTEM_PROMPT` + added catch-all behavioral rule: "For ANY question requiring live data, call the tool. Never answer from training memory."
+
+### Streaming TTS (`cb0db0d`)
+- New: sentence-by-sentence speech dispatch while generation continues.
+- Producer/consumer pattern — `on_text` callback pushes tokens into an `asyncio.Queue`; background `_speak_streaming` task drains it, buffers until sentence boundary (`.!?` + whitespace), sends each sentence to the SAPI daemon.
+- Both Ollama HTTP stream and SAPI subprocess are async I/O — they genuinely interleave at the event loop.
+- Tool-call markers (`[tool: …]`) filtered from TTS queue — display-only.
+
+## Usage
+
+```bash
+# Start MCP server (one-time)
+uv run python server.py
+
+# Pick your mode
+uv run python agent_friday.py repl        # text in, text out
+uv run python agent_friday.py voice       # text in, voice out
+uv run python agent_friday.py fullvoice   # mic in, voice out
+
+# Optional: expose all 18 tools (slower prefill)
+FRIDAY_TOOLS=* uv run python agent_friday.py voice
+```
+
+## Testing notes
+
+- Requires Ollama running with `qwen2.5:7b-instruct` (or set `OLLAMA_MODEL` to another tool-capable model — `qwen2.5-coder:7b`, `llama3.1:latest` also work).
+- First turn on cold cache: ~60s. Subsequent turns: ~3-8s to first audible word.
+- On Windows with R:\models Ollama config, mount R: before launching or Ollama will fail with `mkdir R:\models: The system cannot find the path specified`.
+
+## Commits
+
+```
+cb0db0d feat(voice): stream TTS sentence-by-sentence as LLM generates
+f469466 chore: update uv.lock for faster-whisper/sounddevice/numpy deps
+c6404f7 fix(tool-calling): default qwen2.5:7b, document get_current_time, enforce live-data rule
+dff3edf add STT deps for fullvoice mode
+85b5058 add fullvoice subcommand — mic -> STT -> LLM -> TTS
+c1b5555 add mic-based STT module for fullvoice mode
+82fb15d wire MCP tool calling into REPL and voice modes
+145c66f add MCP tool bridge for REPL and voice modes
+1cab2a3 feat(voice): add local TTS subcommand — FRIDAY speaks her replies
+5a227f8 feat(repl): add text REPL subcommand bypassing LiveKit console
+6b7e6a3 fix(ollama): stop LLM timeout storms + instant greeting
+35d9957 fix: replace Unicode box-drawing chars in main.py with ASCII
+36330bb feat: add Ollama as a local LLM provider
+```

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -28,6 +28,13 @@ End-to-end upgrade of the FRIDAY voice agent: the model now calls MCP tools, spe
 - Default model bumped to `qwen2.5:7b-instruct` — `llama3.2:1b` emits tool calls as free text (broken on Ollama's OpenAI-compat layer).
 - Documented `get_current_time` in `SYSTEM_PROMPT` + added catch-all behavioral rule: "For ANY question requiring live data, call the tool. Never answer from training memory."
 
+### Persistent session memory (`0bec5e0`, `ee8dcd6`)
+- Reminders (`add_reminder` / `list_reminders` / `clear_reminders`) now survive MCP server restarts and reboots.
+- Backed by `~/.friday/reminders.json` — lazy-loaded on first tool call, flushed after every mutation.
+- Best-effort persistence: disk errors are logged but never raised; reminders still work in memory if the disk write fails.
+- Corrupt JSON falls back to empty instead of crashing.
+- 4 smoke tests exercise the roundtrip, fresh-install, corrupt-file, and clear paths.
+
 ### Streaming TTS (`cb0db0d`)
 - New: sentence-by-sentence speech dispatch while generation continues.
 - Producer/consumer pattern — `on_text` callback pushes tokens into an `asyncio.Queue`; background `_speak_streaming` task drains it, buffers until sentence boundary (`.!?` + whitespace), sends each sentence to the SAPI daemon.

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -13,6 +13,7 @@ Run:
 """
 
 import os
+import re
 import sys
 import logging
 import subprocess
@@ -717,6 +718,37 @@ async def _run_repl() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Streaming TTS helper — speaks sentences as they arrive from the LLM stream.
+# WHY: buffering the entire reply then speaking adds 15-60s of silence on CPU.
+# Running a consumer task in parallel with generation means the user hears the
+# first sentence ~3-5s after asking, while the model keeps producing the rest.
+# ---------------------------------------------------------------------------
+
+_SENT_SPLIT = re.compile(r'(?<=[.!?])\s+')
+
+
+async def _speak_streaming(
+    tts_queue: "asyncio.Queue[str | None]",
+    speak,
+) -> None:
+    """Drain tts_queue and speak sentence-by-sentence until None sentinel."""
+    buf = ""
+    while True:
+        chunk = await tts_queue.get()
+        if chunk is None:
+            if buf.strip():
+                await speak(buf.strip())
+            return
+        buf += chunk
+        parts = _SENT_SPLIT.split(buf)
+        if len(parts) > 1:
+            for sentence in parts[:-1]:
+                if sentence.strip():
+                    await speak(sentence.strip())
+            buf = parts[-1]
+
+
+# ---------------------------------------------------------------------------
 # Voice REPL  — text-in, voice-out. FRIDAY *speaks* her replies via Windows
 # SAPI (pyttsx3).  Zero cloud keys, zero model downloads — the voice engine
 # ships with Windows.  STT is still text-typed; add faster-whisper later for
@@ -880,16 +912,33 @@ async def _run_voice(voice_input: bool = False) -> None:
             ctx.add_message(role="user", content=user_input)
 
             print("friday> ", end="", flush=True)
+            # Stream tokens to a queue so TTS speaks sentence-by-sentence in
+            # parallel with generation — first word audible ~3s, not ~60s.
+            tts_queue: asyncio.Queue = asyncio.Queue()
+            consumer = asyncio.create_task(_speak_streaming(tts_queue, speak))
+
+            def _emit_stream(s: str) -> None:
+                _emit(s)
+                # Skip [tool: ...] markers — display-only, not for speech
+                if "[tool:" not in s:
+                    tts_queue.put_nowait(s)
+
             try:
-                full = await _chat_with_tools(llm, ctx, tools, dispatch, conn_opts, _emit)
+                full = await _chat_with_tools(
+                    llm, ctx, tools, dispatch, conn_opts, _emit_stream
+                )
                 print()
             except Exception as exc:
                 print(f"\n[llm error: {exc}]")
+                tts_queue.put_nowait(None)
+                await consumer
                 continue
+
+            tts_queue.put_nowait(None)  # signal consumer: generation done
+            await consumer              # wait for last sentence to finish
 
             if full:
                 ctx.add_message(role="assistant", content=full)
-                await speak(full)
     finally:
         if mcp_client is not None:
             try:

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -549,15 +549,148 @@ async def _run_repl() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Voice REPL  — text-in, voice-out. FRIDAY *speaks* her replies via Windows
+# SAPI (pyttsx3).  Zero cloud keys, zero model downloads — the voice engine
+# ships with Windows.  STT is still text-typed; add faster-whisper later for
+# a full mic→STT→LLM→TTS→speaker loop.
+# ---------------------------------------------------------------------------
+
+async def _run_voice() -> None:
+    import asyncio
+    from livekit.agents.llm import ChatContext
+
+    logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    # TTS via a persistent PowerShell daemon.
+    # Rationale: pyttsx3 + asyncio.to_thread deadlocks on Windows (SAPI needs
+    # an STA COM apartment; asyncio workers are MTA).  Spawning one PS process
+    # per utterance works but pays ~15s .NET JIT per spawn.  A single long-
+    # lived daemon amortizes startup, then each utterance is a stdin write +
+    # blocking .Speak() + sentinel echo for sync.
+    DAEMON_SCRIPT = (
+        "Add-Type -AssemblyName System.Speech;"
+        "$s = New-Object System.Speech.Synthesis.SpeechSynthesizer;"
+        "$s.Rate = 1;"
+        "foreach ($v in $s.GetInstalledVoices()) {"
+        "  if ($v.VoiceInfo.Name -like '*Zira*') {"
+        "    $s.SelectVoice($v.VoiceInfo.Name); break"
+        "  }"
+        "};"
+        "[Console]::Out.WriteLine('READY');"
+        "while (($line = [Console]::In.ReadLine()) -ne $null) {"
+        "  if ($line -eq '__EXIT__') { break };"
+        "  $s.Speak($line);"
+        "  [Console]::Out.WriteLine('DONE')"
+        "}"
+    )
+
+    print("[tts] starting SAPI daemon (one-time ~5s .NET init)...", flush=True)
+    tts_proc = await asyncio.create_subprocess_exec(
+        "powershell.exe", "-NoProfile", "-Command", DAEMON_SCRIPT,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    # Wait for READY line so we don't race the first .Speak()
+    ready = await tts_proc.stdout.readline()
+    if ready.strip() != b"READY":
+        print("[tts] daemon failed to start — falling back to silent mode")
+        tts_proc = None
+
+    async def speak(text: str) -> None:
+        if not text or tts_proc is None or tts_proc.stdin is None:
+            return
+        # Collapse whitespace and strip problematic chars for a single stdin line
+        line = " ".join(text.split())
+        tts_proc.stdin.write((line + "\n").encode("utf-8", errors="replace"))
+        await tts_proc.stdin.drain()
+        # Wait for DONE sentinel so REPL prompt doesn't reappear mid-speech
+        await tts_proc.stdout.readline()
+
+    async def shutdown_tts() -> None:
+        if tts_proc and tts_proc.stdin:
+            try:
+                tts_proc.stdin.write(b"__EXIT__\n")
+                await tts_proc.stdin.drain()
+            except Exception:
+                pass
+            try:
+                await asyncio.wait_for(tts_proc.wait(), timeout=3.0)
+            except asyncio.TimeoutError:
+                tts_proc.kill()
+
+    print()
+    print("=" * 60)
+    print("  F.R.I.D.A.Y. — voice REPL  (TTS: Windows SAPI / Zira | LLM: %s)" % LLM_PROVIDER)
+    print("  type your question — FRIDAY will type AND speak the reply")
+    print("  type 'exit' / 'quit' / Ctrl-C to leave")
+    print("=" * 60)
+
+    llm = _build_llm()
+    conn_opts = APIConnectOptions(timeout=300.0, max_retry=0, retry_interval=2.0)
+
+    ctx = ChatContext()
+    ctx.add_message(role="system", content=SYSTEM_PROMPT)
+
+    print()
+    print("friday> " + _GREETING)
+    ctx.add_message(role="assistant", content=_GREETING)
+    await speak(_GREETING)
+
+    while True:
+        try:
+            user_input = input("\nyou> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nfriday> signing off, boss.")
+            await speak("signing off, boss.")
+            await shutdown_tts()
+            return
+
+        if not user_input:
+            continue
+        if user_input.lower() in {"exit", "quit", "bye", ":q"}:
+            print("friday> signing off, boss.")
+            await speak("signing off, boss.")
+            await shutdown_tts()
+            return
+
+        ctx.add_message(role="user", content=user_input)
+
+        print("friday> ", end="", flush=True)
+        chunks: list[str] = []
+        try:
+            async with llm.chat(chat_ctx=ctx, conn_options=conn_opts) as stream:
+                async for chunk in stream:
+                    delta = getattr(chunk, "delta", None)
+                    content = getattr(delta, "content", None) if delta else None
+                    if content:
+                        print(content, end="", flush=True)
+                        chunks.append(content)
+            print()
+        except Exception as exc:
+            print(f"\n[llm error: {exc}]")
+            continue
+
+        full = "".join(chunks).strip()
+        if full:
+            ctx.add_message(role="assistant", content=full)
+            await speak(full)
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def main():
-    # Route 'repl' subcommand to our text REPL BEFORE handing off to LiveKit's
-    # cli.run_app, which would reject an unknown subcommand.
+    # Route 'repl' / 'voice' subcommands BEFORE LiveKit's cli.run_app takes
+    # over, because cli.run_app would reject any unknown subcommand.
     if len(sys.argv) > 1 and sys.argv[1] == "repl":
         import asyncio
         asyncio.run(_run_repl())
+        return
+    if len(sys.argv) > 1 and sys.argv[1] == "voice":
+        import asyncio
+        asyncio.run(_run_voice())
         return
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -29,11 +29,18 @@ from livekit.plugins import google as lk_google, openai as lk_openai, sarvam, si
 # ---------------------------------------------------------------------------
 
 STT_PROVIDER       = "sarvam"
-LLM_PROVIDER       = "gemini"
+LLM_PROVIDER       = "gemini"   # "gemini" | "openai" | "ollama"
 TTS_PROVIDER       = "openai"
 
 GEMINI_LLM_MODEL   = "gemini-2.5-flash"
 OPENAI_LLM_MODEL   = "gpt-4o"
+
+# Ollama — runs locally; no API key needed.
+# Set OLLAMA_MODEL to any model you have pulled (e.g. llama3.2, gemma3, mistral).
+# OLLAMA_BASE_URL defaults to localhost:11434 but is auto-resolved to the
+# Windows host IP when the agent is running inside WSL.
+OLLAMA_MODEL       = os.getenv("OLLAMA_MODEL", "llama3.2")
+OLLAMA_BASE_URL    = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
 OPENAI_TTS_MODEL   = "tts-1"
 OPENAI_TTS_VOICE   = "nova"       # "nova" has a clean, confident female tone
@@ -237,6 +244,20 @@ def _mcp_server_url() -> str:
     return url
 
 
+def _ollama_url() -> str:
+    """
+    Return the Ollama base URL, auto-replacing localhost/127.0.0.1 with the
+    Windows host IP when the agent is running inside WSL.
+    Ollama must be running on the host with its API port exposed (default 11434).
+    """
+    url = OLLAMA_BASE_URL
+    if "localhost" in url or "127.0.0.1" in url:
+        host_ip = _get_windows_host_ip()
+        url = url.replace("localhost", host_ip).replace("127.0.0.1", host_ip)
+    logger.info("Ollama URL: %s  model: %s", url, OLLAMA_MODEL)
+    return url
+
+
 # ---------------------------------------------------------------------------
 # Build provider instances
 # ---------------------------------------------------------------------------
@@ -265,6 +286,14 @@ def _build_llm():
     elif LLM_PROVIDER == "gemini":
         logger.info("LLM → Google Gemini (%s)", GEMINI_LLM_MODEL)
         return lk_google.LLM(model=GEMINI_LLM_MODEL, api_key=os.getenv("GOOGLE_API_KEY"))
+    elif LLM_PROVIDER == "ollama":
+        # Ollama's OpenAI-compatible endpoint — no API key required.
+        # Ensure the model is pulled first: `ollama pull llama3.2`
+        return lk_openai.LLM(
+            model=OLLAMA_MODEL,
+            base_url=_ollama_url(),
+            api_key="ollama",          # required by the client lib; not validated
+        )
     else:
         raise ValueError(f"Unknown LLM_PROVIDER: {LLM_PROVIDER!r}")
 

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -51,8 +51,10 @@ GEMINI_LLM_MODEL   = "gemini-2.5-flash"
 OPENAI_LLM_MODEL   = "gpt-4o"
 
 # Ollama — runs locally; no API key needed.
-# Set OLLAMA_MODEL in .env to any pulled model (llama3.1:latest, gemma4, qwen3:8b…)
-OLLAMA_MODEL       = os.getenv("OLLAMA_MODEL", "llama3.1:latest")
+# Set OLLAMA_MODEL in .env to any pulled model — qwen2.5:7b-instruct is the
+# default because it emits proper structured tool_calls via Ollama's OpenAI-compat
+# layer.  llama3.1:latest emits tool calls as raw text (broken on Ollama 0.3+).
+OLLAMA_MODEL       = os.getenv("OLLAMA_MODEL", "qwen2.5:7b-instruct")
 OLLAMA_BASE_URL    = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
 OPENAI_TTS_MODEL   = "tts-1"
@@ -170,13 +172,14 @@ Warm. Slightly curious. Very FRIDAY.
 ## Behavioral Rules
 
 1. Call tools silently and immediately — never say "I'm going to call..." Just do it.
-2. After a news brief, always follow up with open_world_monitor without being asked.
-3. Keep all spoken responses short — two to four sentences maximum.
-4. No bullet points, no markdown, no lists. You are speaking, not writing.
-5. Stay in character. You are F.R.I.D.A.Y. You are not an AI assistant — you are Stark's AI. Act like it.
-6. Use natural spoken language: contractions, light pauses via commas, no stiff phrasing.
-7. Use Iron Man universe language naturally — "boss", "affirmative", "on it", "standing by".
-8. If a tool fails, report it calmly: "News feed's unresponsive right now, boss. Want me to try again?"
+2. For ANY question that requires live data — time, date, weather, prices, news, system health, calculations — call the relevant tool. Never answer these from training memory.
+3. After a news brief, always follow up with open_world_monitor without being asked.
+4. Keep all spoken responses short — two to four sentences maximum.
+5. No bullet points, no markdown, no lists. You are speaking, not writing.
+6. Stay in character. You are F.R.I.D.A.Y. You are not an AI assistant — you are Stark's AI. Act like it.
+7. Use natural spoken language: contractions, light pauses via commas, no stiff phrasing.
+8. Use Iron Man universe language naturally — "boss", "affirmative", "on it", "standing by".
+9. If a tool fails, report it calmly: "News feed's unresponsive right now, boss. Want me to try again?"
 
 ---
 
@@ -201,6 +204,16 @@ Trigger phrases:
 Behavior:
 - Confirm saves briefly: "Got it. Noted."
 - When listing, summarize — don't read them verbatim robotically.
+
+### get_current_time — Live Time & Date
+Returns the actual current time and date from the system clock.
+
+Trigger phrases:
+- "What time is it?" / "What's the time?" / "Current time" / "What's today's date?" / "What day is it?"
+
+Behavior:
+- Call the tool silently. Never answer time/date questions from memory — always use this tool.
+- Example: "It's 11:42 PM on a Thursday, boss."
 
 ### calculate — Math
 Evaluates any arithmetic expression safely: +, -, *, /, **, sqrt(), sin(), cos(), log(), pi, e…
@@ -580,6 +593,44 @@ async def _chat_with_tools(
     return "\n".join(full_text_parts).strip()
 
 
+async def _prewarm_llm(llm, ctx, tools, conn_opts) -> float:
+    """
+    Prime Ollama's KV cache with the system prompt + tool schemas.
+
+    Sends one throwaway chat over a *copy* of the real ChatContext with a
+    trivial user message and drains the stream to completion.  Ollama's
+    OpenAI-compat backend prefix-caches KV by token sequence, so the real
+    first turn reuses ~2000-2500 tokens of prefill and only has to run
+    the new user-message + generation.
+
+    WHY full drain (not early break): closing the stream mid-response can
+    cause Ollama to abort without persisting the KV cache, defeating the
+    purpose.  Completing the request guarantees the prefix is cached.
+
+    Returns elapsed seconds so the caller can report it.  Failures are
+    swallowed — a flaky prewarm must never block the demo.
+    """
+    import time
+
+    try:
+        warm_ctx = ctx.copy()
+        # "say ok" is minimal — 2-token response from most tool-tuned models,
+        # keeps total prewarm cost close to prefill-only without risking the
+        # model deciding to emit a tool call for something substantive.
+        warm_ctx.add_message(role="user", content="reply with exactly: ok")
+        chat_kwargs = {"chat_ctx": warm_ctx, "conn_options": conn_opts}
+        if tools:
+            chat_kwargs["tools"] = tools
+
+        t0 = time.time()
+        async with llm.chat(**chat_kwargs) as stream:
+            async for _chunk in stream:
+                pass  # drain fully so Ollama commits the KV cache
+        return time.time() - t0
+    except Exception:
+        return 0.0
+
+
 # ---------------------------------------------------------------------------
 # Text REPL  — bypasses LiveKit console mode entirely.
 # LiveKit's `console` subcommand hooks a mic/speaker pipeline by default and is
@@ -620,6 +671,13 @@ async def _run_repl() -> None:
     print()
     print("friday> " + _GREETING)
     ctx.add_message(role="assistant", content=_GREETING)
+
+    # Prewarm Ollama's KV cache with system + tools + greeting prefix so the
+    # real first user turn only has to prefill the user message + generation.
+    if tools:
+        print("[warmup] priming model cache (first run: ~60-180s)...", flush=True)
+        elapsed = await _prewarm_llm(llm, ctx, tools, conn_opts)
+        print(f"[warmup] done in {elapsed:.1f}s — next turn should be snappy")
 
     def _emit(s: str) -> None:
         print(s, end="", flush=True)
@@ -768,7 +826,20 @@ async def _run_voice(voice_input: bool = False) -> None:
     print()
     print("friday> " + _GREETING)
     ctx.add_message(role="assistant", content=_GREETING)
-    await speak(_GREETING)
+
+    # Overlap TTS of the greeting with model prewarm — SAPI runs in a
+    # separate PowerShell process, Ollama in another, so they don't contend.
+    # By the time the greeting finishes speaking (~5s), the KV cache is
+    # usually primed, making the first user turn feel instant.
+    if tools:
+        print("[warmup] priming model cache in parallel with greeting...", flush=True)
+        _, elapsed = await asyncio.gather(
+            speak(_GREETING),
+            _prewarm_llm(llm, ctx, tools, conn_opts),
+        )
+        print(f"[warmup] model cache ready ({elapsed:.1f}s)")
+    else:
+        await speak(_GREETING)
 
     def _emit(s: str) -> None:
         print(s, end="", flush=True)

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -485,10 +485,80 @@ async def entrypoint(ctx: JobContext) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Text REPL  — bypasses LiveKit console mode entirely.
+# LiveKit's `console` subcommand hooks a mic/speaker pipeline by default and is
+# awkward for pure-text Ollama sessions.  `repl` drives the same patched LLM
+# with plain input()/print() so you get an instant greeting and a normal shell.
+# ---------------------------------------------------------------------------
+
+async def _run_repl() -> None:
+    import asyncio  # noqa: F401 — used by caller
+    from livekit.agents.llm import ChatContext
+
+    logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    print()
+    print("=" * 60)
+    print("  F.R.I.D.A.Y. — text REPL  (LLM: %s | model: %s)" % (LLM_PROVIDER, OLLAMA_MODEL))
+    print("  type 'exit' / 'quit' / Ctrl-C to leave")
+    print("=" * 60)
+
+    llm = _build_llm()  # inherits httpx + APIConnectOptions timeout fixes
+    conn_opts = APIConnectOptions(timeout=300.0, max_retry=0, retry_interval=2.0)
+
+    ctx = ChatContext()
+    ctx.add_message(role="system", content=SYSTEM_PROMPT)
+
+    # Canned greeting — no LLM call, instant UX
+    print()
+    print("friday> " + _GREETING)
+    ctx.add_message(role="assistant", content=_GREETING)
+
+    while True:
+        try:
+            user_input = input("\nyou> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nfriday> signing off, boss.")
+            return
+
+        if not user_input:
+            continue
+        if user_input.lower() in {"exit", "quit", "bye", ":q"}:
+            print("friday> signing off, boss.")
+            return
+
+        ctx.add_message(role="user", content=user_input)
+
+        print("friday> ", end="", flush=True)
+        chunks: list[str] = []
+        try:
+            async with llm.chat(chat_ctx=ctx, conn_options=conn_opts) as stream:
+                async for chunk in stream:
+                    delta = getattr(chunk, "delta", None)
+                    content = getattr(delta, "content", None) if delta else None
+                    if content:
+                        print(content, end="", flush=True)
+                        chunks.append(content)
+            print()
+        except Exception as exc:
+            print(f"\n[llm error: {exc}]")
+            continue
+
+        full = "".join(chunks).strip()
+        if full:
+            ctx.add_message(role="assistant", content=full)
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
 def main():
+    # Route 'repl' subcommand to our text REPL BEFORE handing off to LiveKit's
+    # cli.run_app, which would reject an unknown subcommand.
+    if len(sys.argv) > 1 and sys.argv[1] == "repl":
+        import asyncio
+        asyncio.run(_run_repl())
+        return
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 
 def dev():

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -665,10 +665,18 @@ async def _run_repl() -> None:
 # a full mic→STT→LLM→TTS→speaker loop.
 # ---------------------------------------------------------------------------
 
-async def _run_voice() -> None:
+async def _run_voice(voice_input: bool = False) -> None:
+    """Voice REPL.  voice_input=True adds mic-based PTT via faster-whisper."""
     import asyncio
     from livekit.agents.llm import ChatContext
     from friday_mcp import open_mcp
+
+    # STT loaded lazily — only if voice_input requested.
+    whisper = None
+    if voice_input:
+        from friday_stt import load_whisper, record_until_enter, transcribe
+        print("[stt] loading whisper (first run downloads ~75MB)...", flush=True)
+        whisper = load_whisper("tiny.en")
 
     logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
@@ -732,9 +740,13 @@ async def _run_voice() -> None:
 
     print()
     print("=" * 60)
-    print("  F.R.I.D.A.Y. — voice REPL  (TTS: Windows SAPI / Zira | LLM: %s)" % LLM_PROVIDER)
-    print("  type your question — FRIDAY will type AND speak the reply")
-    print("  type 'exit' / 'quit' / Ctrl-C to leave")
+    mode = "fullvoice (mic -> STT -> LLM -> TTS)" if voice_input else "voice (text -> LLM -> TTS)"
+    print(f"  F.R.I.D.A.Y. — {mode}  (LLM: {LLM_PROVIDER})")
+    if voice_input:
+        print("  press ENTER to talk, ENTER again to stop.  type 'exit' to quit.")
+    else:
+        print("  type your question — FRIDAY will type AND speak the reply")
+        print("  type 'exit' / 'quit' / Ctrl-C to leave")
     print("=" * 60)
 
     llm = _build_llm()
@@ -761,10 +773,27 @@ async def _run_voice() -> None:
     def _emit(s: str) -> None:
         print(s, end="", flush=True)
 
+    async def _read_turn() -> str:
+        """Get the next user turn — mic or keyboard depending on voice_input."""
+        if not voice_input:
+            return input("\nyou> ").strip()
+        # Offload blocking record+transcribe so the event loop stays responsive.
+        print()
+        audio = await asyncio.to_thread(record_until_enter)
+        if audio.size == 0:
+            return ""
+        print("[stt] transcribing...", flush=True)
+        text = await asyncio.to_thread(transcribe, whisper, audio)
+        if text:
+            print(f"you> {text}")
+        else:
+            print("[stt] (no speech detected)")
+        return text.strip()
+
     try:
         while True:
             try:
-                user_input = input("\nyou> ").strip()
+                user_input = await _read_turn()
             except (EOFError, KeyboardInterrupt):
                 print("\nfriday> signing off, boss.")
                 await speak("signing off, boss.")
@@ -812,7 +841,11 @@ def main():
         return
     if len(sys.argv) > 1 and sys.argv[1] == "voice":
         import asyncio
-        asyncio.run(_run_voice())
+        asyncio.run(_run_voice(voice_input=False))
+        return
+    if len(sys.argv) > 1 and sys.argv[1] == "fullvoice":
+        import asyncio
+        asyncio.run(_run_voice(voice_input=True))
         return
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))
 

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -65,6 +65,22 @@ SARVAM_TTS_SPEAKER  = "rahul"
 # MCP server running on Windows host
 MCP_SERVER_PORT = 8000
 
+# Tool allowlist for REPL / voice modes.  Small models + CPU can't afford
+# 18 tool schemas in prefill — set FRIDAY_TOOLS=* (or "all") to expose all,
+# or CSV override to customize.  Default: 6 demo-critical tools → ~60s prefill.
+_DEFAULT_TOOLS = (
+    "get_current_time,get_weather,get_stock_price,"
+    "search_web,get_world_news,get_system_diagnostics"
+)
+FRIDAY_TOOLS = os.getenv("FRIDAY_TOOLS", _DEFAULT_TOOLS)
+
+
+def _tool_allowlist() -> list[str] | None:
+    raw = FRIDAY_TOOLS.strip()
+    if raw in {"*", "all", ""}:
+        return None  # expose all
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
 # ---------------------------------------------------------------------------
 # System prompt – F.R.I.D.A.Y.
 # ---------------------------------------------------------------------------
@@ -321,7 +337,9 @@ def _build_llm():
         # Two separate timeouts to fix:
         #   1. httpx read timeout (default 5s) — pass explicit httpx.Timeout
         #   2. APIConnectOptions.timeout (default 10s, frozen dataclass) — wrap chat()
-        _timeout = httpx.Timeout(connect=15.0, read=120.0, write=30.0, pool=15.0)
+        # read=600s — prefill with 18-tool schema on CPU measured at ~170s cold.
+        # KV cache amortizes subsequent calls, but first tool turn needs headroom.
+        _timeout = httpx.Timeout(connect=15.0, read=600.0, write=30.0, pool=15.0)
         llm = lk_openai.LLM(
             model=OLLAMA_MODEL,
             base_url=_ollama_url(),
@@ -485,6 +503,84 @@ async def entrypoint(ctx: JobContext) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shared chat driver with tool-calling.
+# LiveKit streams text content AND partial tool-call deltas over the same
+# ChatChunk iterator.  We collect both, then if tool calls landed, dispatch
+# them via the MCP client, append FunctionCall + FunctionCallOutput items to
+# the ChatContext, and re-invoke llm.chat() so the model can continue with
+# the tool results in context.  Capped at 4 iterations as a runaway guard.
+# ---------------------------------------------------------------------------
+
+async def _chat_with_tools(
+    llm,
+    ctx,
+    tools,
+    dispatch,
+    conn_opts,
+    on_text,
+    *,
+    max_iters: int = 4,
+) -> str:
+    from livekit.agents.llm import FunctionCall, FunctionCallOutput
+
+    full_text_parts: list[str] = []
+
+    for _ in range(max_iters):
+        iter_text: list[str] = []
+        # call_id -> {"name": str, "arguments": str}
+        tool_calls: dict[str, dict] = {}
+
+        chat_kwargs = {"chat_ctx": ctx, "conn_options": conn_opts}
+        if tools:
+            chat_kwargs["tools"] = tools
+
+        async with llm.chat(**chat_kwargs) as stream:
+            async for chunk in stream:
+                delta = getattr(chunk, "delta", None)
+                if delta is None:
+                    continue
+                if delta.content:
+                    on_text(delta.content)
+                    iter_text.append(delta.content)
+                # Deltas may carry partial tool calls — merge by call_id.
+                for tc in (delta.tool_calls or []):
+                    slot = tool_calls.setdefault(tc.call_id, {"name": "", "arguments": ""})
+                    if tc.name:
+                        slot["name"] = tc.name
+                    if tc.arguments:
+                        slot["arguments"] += tc.arguments
+
+        text_this_iter = "".join(iter_text).strip()
+        if text_this_iter:
+            full_text_parts.append(text_this_iter)
+
+        if not tool_calls:
+            break  # plain text answer — we're done
+
+        # Record the assistant's tool-call intent, then each tool's result.
+        items = []
+        for call_id, info in tool_calls.items():
+            items.append(FunctionCall(
+                call_id=call_id,
+                name=info["name"],
+                arguments=info["arguments"],
+            ))
+        ctx.insert(items)
+
+        for call_id, info in tool_calls.items():
+            on_text(f"\n[tool: {info['name']}({info['arguments'][:80]})]\n")
+            result = await dispatch(info["name"], info["arguments"])
+            ctx.insert(FunctionCallOutput(
+                call_id=call_id,
+                name=info["name"],
+                output=result,
+                is_error=False,
+            ))
+
+    return "\n".join(full_text_parts).strip()
+
+
+# ---------------------------------------------------------------------------
 # Text REPL  — bypasses LiveKit console mode entirely.
 # LiveKit's `console` subcommand hooks a mic/speaker pipeline by default and is
 # awkward for pure-text Ollama sessions.  `repl` drives the same patched LLM
@@ -494,6 +590,7 @@ async def entrypoint(ctx: JobContext) -> None:
 async def _run_repl() -> None:
     import asyncio  # noqa: F401 — used by caller
     from livekit.agents.llm import ChatContext
+    from friday_mcp import open_mcp
 
     logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     print()
@@ -503,7 +600,18 @@ async def _run_repl() -> None:
     print("=" * 60)
 
     llm = _build_llm()  # inherits httpx + APIConnectOptions timeout fixes
-    conn_opts = APIConnectOptions(timeout=300.0, max_retry=0, retry_interval=2.0)
+    conn_opts = APIConnectOptions(timeout=600.0, max_retry=0, retry_interval=2.0)
+
+    # Connect to the MCP server for tools.  Fails soft — if the server is
+    # down, the REPL still works as a plain chat.
+    mcp_client = None
+    tools = []
+    dispatch = None
+    try:
+        mcp_client, tools, dispatch = await open_mcp(_mcp_server_url(), allow=_tool_allowlist())
+        print(f"[mcp] {len(tools)} tools loaded from {_mcp_server_url()}")
+    except Exception as exc:
+        print(f"[mcp] unavailable ({exc}) — running without tools")
 
     ctx = ChatContext()
     ctx.add_message(role="system", content=SYSTEM_PROMPT)
@@ -513,39 +621,41 @@ async def _run_repl() -> None:
     print("friday> " + _GREETING)
     ctx.add_message(role="assistant", content=_GREETING)
 
-    while True:
-        try:
-            user_input = input("\nyou> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print("\nfriday> signing off, boss.")
-            return
+    def _emit(s: str) -> None:
+        print(s, end="", flush=True)
 
-        if not user_input:
-            continue
-        if user_input.lower() in {"exit", "quit", "bye", ":q"}:
-            print("friday> signing off, boss.")
-            return
+    try:
+        while True:
+            try:
+                user_input = input("\nyou> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nfriday> signing off, boss.")
+                return
 
-        ctx.add_message(role="user", content=user_input)
+            if not user_input:
+                continue
+            if user_input.lower() in {"exit", "quit", "bye", ":q"}:
+                print("friday> signing off, boss.")
+                return
 
-        print("friday> ", end="", flush=True)
-        chunks: list[str] = []
-        try:
-            async with llm.chat(chat_ctx=ctx, conn_options=conn_opts) as stream:
-                async for chunk in stream:
-                    delta = getattr(chunk, "delta", None)
-                    content = getattr(delta, "content", None) if delta else None
-                    if content:
-                        print(content, end="", flush=True)
-                        chunks.append(content)
-            print()
-        except Exception as exc:
-            print(f"\n[llm error: {exc}]")
-            continue
+            ctx.add_message(role="user", content=user_input)
 
-        full = "".join(chunks).strip()
-        if full:
-            ctx.add_message(role="assistant", content=full)
+            print("friday> ", end="", flush=True)
+            try:
+                full = await _chat_with_tools(llm, ctx, tools, dispatch, conn_opts, _emit)
+                print()
+            except Exception as exc:
+                print(f"\n[llm error: {exc}]")
+                continue
+
+            if full:
+                ctx.add_message(role="assistant", content=full)
+    finally:
+        if mcp_client is not None:
+            try:
+                await mcp_client.close()
+            except Exception:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -558,6 +668,7 @@ async def _run_repl() -> None:
 async def _run_voice() -> None:
     import asyncio
     from livekit.agents.llm import ChatContext
+    from friday_mcp import open_mcp
 
     logging.basicConfig(level=logging.WARNING, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
@@ -627,7 +738,17 @@ async def _run_voice() -> None:
     print("=" * 60)
 
     llm = _build_llm()
-    conn_opts = APIConnectOptions(timeout=300.0, max_retry=0, retry_interval=2.0)
+    conn_opts = APIConnectOptions(timeout=600.0, max_retry=0, retry_interval=2.0)
+
+    # Connect to MCP for tool calling (soft-fail).
+    mcp_client = None
+    tools = []
+    dispatch = None
+    try:
+        mcp_client, tools, dispatch = await open_mcp(_mcp_server_url(), allow=_tool_allowlist())
+        print(f"[mcp] {len(tools)} tools loaded from {_mcp_server_url()}")
+    except Exception as exc:
+        print(f"[mcp] unavailable ({exc}) — running without tools")
 
     ctx = ChatContext()
     ctx.add_message(role="system", content=SYSTEM_PROMPT)
@@ -637,44 +758,45 @@ async def _run_voice() -> None:
     ctx.add_message(role="assistant", content=_GREETING)
     await speak(_GREETING)
 
-    while True:
-        try:
-            user_input = input("\nyou> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print("\nfriday> signing off, boss.")
-            await speak("signing off, boss.")
-            await shutdown_tts()
-            return
+    def _emit(s: str) -> None:
+        print(s, end="", flush=True)
 
-        if not user_input:
-            continue
-        if user_input.lower() in {"exit", "quit", "bye", ":q"}:
-            print("friday> signing off, boss.")
-            await speak("signing off, boss.")
-            await shutdown_tts()
-            return
+    try:
+        while True:
+            try:
+                user_input = input("\nyou> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nfriday> signing off, boss.")
+                await speak("signing off, boss.")
+                return
 
-        ctx.add_message(role="user", content=user_input)
+            if not user_input:
+                continue
+            if user_input.lower() in {"exit", "quit", "bye", ":q"}:
+                print("friday> signing off, boss.")
+                await speak("signing off, boss.")
+                return
 
-        print("friday> ", end="", flush=True)
-        chunks: list[str] = []
-        try:
-            async with llm.chat(chat_ctx=ctx, conn_options=conn_opts) as stream:
-                async for chunk in stream:
-                    delta = getattr(chunk, "delta", None)
-                    content = getattr(delta, "content", None) if delta else None
-                    if content:
-                        print(content, end="", flush=True)
-                        chunks.append(content)
-            print()
-        except Exception as exc:
-            print(f"\n[llm error: {exc}]")
-            continue
+            ctx.add_message(role="user", content=user_input)
 
-        full = "".join(chunks).strip()
-        if full:
-            ctx.add_message(role="assistant", content=full)
-            await speak(full)
+            print("friday> ", end="", flush=True)
+            try:
+                full = await _chat_with_tools(llm, ctx, tools, dispatch, conn_opts, _emit)
+                print()
+            except Exception as exc:
+                print(f"\n[llm error: {exc}]")
+                continue
+
+            if full:
+                ctx.add_message(role="assistant", content=full)
+                await speak(full)
+    finally:
+        if mcp_client is not None:
+            try:
+                await mcp_client.close()
+            except Exception:
+                pass
+        await shutdown_tts()
 
 
 # ---------------------------------------------------------------------------

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -13,33 +13,46 @@ Run:
 """
 
 import os
+import sys
 import logging
 import subprocess
+import httpx
+
+# Force UTF-8 on Windows (cp1252 can't encode emojis used by LiveKit/rich)
+os.environ.setdefault("PYTHONUTF8", "1")
+if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr and hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 from dotenv import load_dotenv
+
+# Load .env BEFORE reading any os.getenv() constants so env vars are available
+load_dotenv()
+
 from livekit.agents import JobContext, WorkerOptions, cli
 from livekit.agents.voice import Agent, AgentSession
+from livekit.agents.voice.agent_session import SessionConnectOptions
 from livekit.agents.llm import mcp
+from livekit.agents.types import APIConnectOptions
 
 # Plugins
 from livekit.plugins import google as lk_google, openai as lk_openai, sarvam, silero
 
 # ---------------------------------------------------------------------------
-# CONFIG
+# CONFIG  (all os.getenv calls happen after load_dotenv() above)
 # ---------------------------------------------------------------------------
 
 STT_PROVIDER       = "sarvam"
-LLM_PROVIDER       = "gemini"   # "gemini" | "openai" | "ollama"
+LLM_PROVIDER       = "ollama"   # "gemini" | "openai" | "ollama"
 TTS_PROVIDER       = "openai"
 
 GEMINI_LLM_MODEL   = "gemini-2.5-flash"
 OPENAI_LLM_MODEL   = "gpt-4o"
 
 # Ollama — runs locally; no API key needed.
-# Set OLLAMA_MODEL to any model you have pulled (e.g. llama3.2, gemma3, mistral).
-# OLLAMA_BASE_URL defaults to localhost:11434 but is auto-resolved to the
-# Windows host IP when the agent is running inside WSL.
-OLLAMA_MODEL       = os.getenv("OLLAMA_MODEL", "llama3.2")
+# Set OLLAMA_MODEL in .env to any pulled model (llama3.1:latest, gemma4, qwen3:8b…)
+OLLAMA_MODEL       = os.getenv("OLLAMA_MODEL", "llama3.1:latest")
 OLLAMA_BASE_URL    = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
 OPENAI_TTS_MODEL   = "tts-1"
@@ -196,8 +209,6 @@ Behavior:
 # Bootstrap
 # ---------------------------------------------------------------------------
 
-load_dotenv()
-
 logger = logging.getLogger("friday-agent")
 logger.setLevel(logging.INFO)
 
@@ -279,6 +290,25 @@ def _build_stt():
         raise ValueError(f"Unknown STT_PROVIDER: {STT_PROVIDER!r}")
 
 
+def _patch_llm_conn_options(llm_instance, *, timeout: float = 120.0):
+    """
+    Wrap llm.chat() so every call uses a generous conn_options.
+    APIConnectOptions is a frozen dataclass — the only way to override its
+    10-second default is to pass conn_options explicitly at each call site.
+    """
+    _opts = APIConnectOptions(timeout=timeout, max_retry=3, retry_interval=2.0)
+    _original_chat = llm_instance.chat
+
+    def _chat_with_timeout(**kwargs):
+        # Only inject if caller didn't supply their own conn_options
+        kwargs.setdefault("conn_options", _opts)
+        return _original_chat(**kwargs)
+
+    llm_instance.chat = _chat_with_timeout
+    logger.info("LLM chat() patched: conn_options.timeout=%.0fs", timeout)
+    return llm_instance
+
+
 def _build_llm():
     if LLM_PROVIDER == "openai":
         logger.info("LLM → OpenAI (%s)", OPENAI_LLM_MODEL)
@@ -288,12 +318,17 @@ def _build_llm():
         return lk_google.LLM(model=GEMINI_LLM_MODEL, api_key=os.getenv("GOOGLE_API_KEY"))
     elif LLM_PROVIDER == "ollama":
         # Ollama's OpenAI-compatible endpoint — no API key required.
-        # Ensure the model is pulled first: `ollama pull llama3.2`
-        return lk_openai.LLM(
+        # Two separate timeouts to fix:
+        #   1. httpx read timeout (default 5s) — pass explicit httpx.Timeout
+        #   2. APIConnectOptions.timeout (default 10s, frozen dataclass) — wrap chat()
+        _timeout = httpx.Timeout(connect=15.0, read=120.0, write=30.0, pool=15.0)
+        llm = lk_openai.LLM(
             model=OLLAMA_MODEL,
             base_url=_ollama_url(),
-            api_key="ollama",          # required by the client lib; not validated
+            api_key="ollama",          # required by client lib; not validated
+            timeout=_timeout,
         )
+        return _patch_llm_conn_options(llm, timeout=120.0)
     else:
         raise ValueError(f"Unknown LLM_PROVIDER: {LLM_PROVIDER!r}")
 
@@ -318,33 +353,86 @@ def _build_tts():
 # Agent
 # ---------------------------------------------------------------------------
 
+def _is_console_mode() -> bool:
+    """True when the agent is launched with the 'console' subcommand (text-only, no audio)."""
+    return "console" in sys.argv
+
+
+_GREETING = "Greetings boss, you're awake late at night today. What you up to?"
+
+# Tokens in system-prompt + MCP tool schemas can exceed 5 000 on CPU-only hardware,
+# making Ollama's prefill take 5-10 min. We bypass the LLM for the opening line so
+# the session feels instant, then Ollama handles all real user questions.
+_GREETING_INSTRUCTION_FRAGMENT = "Greet the user exactly with"
+
+
 class FridayAgent(Agent):
     """
     F.R.I.D.A.Y. – Iron Man-style voice assistant.
     All tools are provided via the MCP server on the Windows host.
+    In console mode STT/TTS/VAD are omitted so no cloud audio keys are needed.
     """
 
-    def __init__(self, stt, llm, tts) -> None:
-        super().__init__(
-            instructions=SYSTEM_PROMPT,
-            stt=stt,
-            llm=llm,
-            tts=tts,
-            vad=silero.VAD.load(),
-            mcp_servers=[
+    def __init__(self, llm, stt=None, tts=None) -> None:
+        self._audio_enabled = tts is not None  # track before super().__init__
+        kwargs: dict = {
+            "instructions": SYSTEM_PROMPT,
+            "llm": llm,
+            "mcp_servers": [
                 mcp.MCPServerHTTP(
                     url=_mcp_server_url(),
                     transport_type="sse",
                     client_session_timeout_seconds=30,
                 ),
             ],
-        )
+        }
+        # Audio pipeline — only when STT/TTS are available (i.e. not console mode)
+        if stt:
+            kwargs["stt"] = stt
+            kwargs["vad"] = silero.VAD.load()
+        if tts:
+            kwargs["tts"] = tts
+        super().__init__(**kwargs)
+
+    async def llm_node(self, chat_ctx, tools, model_settings):
+        """
+        Override so the greeting bypasses Ollama entirely.
+        CPU-only inference needs 5-10 min for a 5k-token prompt; the opening
+        line is canned so the session feels instant.  All real questions go
+        through Ollama as normal.
+        """
+        from livekit.agents.types import NOT_GIVEN
+
+        # Detect the greeting instruction injected by on_enter()
+        msgs = chat_ctx.messages()
+        last_msg = msgs[-1] if msgs else None
+        last_text = getattr(last_msg, "content", "") or ""
+        if _GREETING_INSTRUCTION_FRAGMENT in last_text:
+            logger.info("Greeting shortcut — skipping Ollama prefill")
+            yield _GREETING
+            return
+
+        # All other turns: use the real LLM with the session's conn_options
+        activity = self._get_activity_or_raise()
+        conn_opts = activity.session.conn_options.llm_conn_options
+        tool_choice = model_settings.tool_choice if model_settings else NOT_GIVEN
+        async with activity.llm.chat(
+            chat_ctx=chat_ctx,
+            tools=tools,
+            tool_choice=tool_choice,
+            conn_options=conn_opts,
+        ) as stream:
+            async for chunk in stream:
+                yield chunk
 
     async def on_enter(self) -> None:
-        """Greet the user specifically for the late-night lab session."""
+        """Greet the user on session start."""
+        # Disable audio BEFORE generating the first reply so TTS is never invoked
+        if not self._audio_enabled:
+            self.session.output.set_audio_enabled(False)
         await self.session.generate_reply(
             instructions=(
-                "Greet the user exactly with: 'Greetings boss, you're awake late at night today. What you up to?' "
+                f"{_GREETING_INSTRUCTION_FRAGMENT}: '{_GREETING}' "
                 "Maintain a helpful but dry tone."
             )
         )
@@ -363,22 +451,35 @@ def _endpointing_delay() -> float:
 
 
 async def entrypoint(ctx: JobContext) -> None:
-    logger.info(
-        "FRIDAY online – room: %s | STT=%s | LLM=%s | TTS=%s",
-        ctx.room.name, STT_PROVIDER, LLM_PROVIDER, TTS_PROVIDER,
-    )
-
-    stt = _build_stt()
+    console = _is_console_mode()
+    stt = None if console else _build_stt()
     llm = _build_llm()
-    tts = _build_tts()
+    tts = None if console else _build_tts()
 
-    session = AgentSession(
-        turn_detection=_turn_detection(),
-        min_endpointing_delay=_endpointing_delay(),
+    logger.info(
+        "FRIDAY online – mode: %s | STT=%s | LLM=%s | TTS=%s",
+        "console" if console else "voice",
+        STT_PROVIDER if stt else "none",
+        LLM_PROVIDER,
+        TTS_PROVIDER if tts else "none",
     )
+
+    # Generous LLM timeout — local models (Ollama) need 120-300s on CPU-only hardware
+    # because token prefill scales with context length (system prompt + tool schemas).
+    _llm_timeout = 300.0 if LLM_PROVIDER == "ollama" else 30.0
+    _llm_opts = APIConnectOptions(timeout=_llm_timeout, max_retry=0)
+
+    session_kwargs: dict = {
+        "conn_options": SessionConnectOptions(llm_conn_options=_llm_opts),
+    }
+    if not console:
+        session_kwargs["turn_detection"] = _turn_detection()
+        session_kwargs["min_endpointing_delay"] = _endpointing_delay()
+
+    session = AgentSession(**session_kwargs)
 
     await session.start(
-        agent=FridayAgent(stt=stt, llm=llm, tts=tts),
+        agent=FridayAgent(llm=llm, stt=stt, tts=tts),
         room=ctx.room,
     )
 
@@ -392,7 +493,6 @@ def main():
 
 def dev():
     """Wrapper to run the agent in dev mode automatically."""
-    import sys
     # If no command was provided, inject 'dev'
     if len(sys.argv) == 1:
         sys.argv.append("dev")

--- a/agent_friday.py
+++ b/agent_friday.py
@@ -78,12 +78,47 @@ Opens a live world map/dashboard on the host machine.
 - Always call this after delivering a world news brief, unprompted.
 - No need to explain what it does beyond: "Let me open up the world monitor."
 
-### Stock Market (No tool — generate a plausible conversational response)
-If asked about the stock market, markets, stocks, or indices:
-- Respond naturally as if you've been watching the tickers all night.
-- Keep it short: one or two sentences. Sound informed, not robotic.
-- Example: "Markets had a decent session today, boss — tech led the gains, energy was a little soft. Nothing alarming."
-- Vary the response. Do not say the same thing every time.
+### get_stock_price / get_market_overview — Finance
+get_stock_price fetches real-time price and daily change for any ticker (AAPL, TSLA, ^DJI…).
+get_market_overview returns a snapshot of S&P 500, Dow Jones, and NASDAQ.
+
+Trigger phrases:
+- "How's [company] doing?" / "What's TSLA at?" / "Check the markets"
+- "How are stocks today?" / "Market overview"
+
+Behavior:
+- Call the tool silently. Deliver the result in one or two spoken sentences.
+- Example: "Tesla's sitting at $182, down about 1.4% on the day, boss. Nothing dramatic."
+
+### get_weather — Weather
+Fetches current conditions for any city via Open-Meteo (no API key required).
+
+Trigger phrases:
+- "What's the weather in [city]?" / "How's it looking in [city]?" / "Temperature in [city]"
+
+Behavior:
+- Call silently. Speak the result naturally — temperature, condition, wind, humidity.
+- Example: "Mumbai's at 31°C right now, partly cloudy. Humidity's high — 78%. Typical."
+
+### get_system_diagnostics — System Health
+Returns live CPU usage, RAM usage, and battery status from the host machine.
+
+Trigger phrases:
+- "How's the system running?" / "RAM check" / "CPU usage" / "Battery status" / "System health"
+
+Behavior:
+- Report the key numbers conversationally.
+- Example: "CPU's at 22%, RAM's 9.4 of 16 gigs. Battery at 74%, plugged in."
+
+### create_ticket / list_tickets — Task Management
+create_ticket logs a new task. list_tickets retrieves open or all tasks.
+
+Trigger phrases:
+- "Note that…" / "Add a task…" / "What's on the list?" / "Open tasks"
+
+Behavior:
+- Confirm ticket creation with a brief acknowledgment.
+- Summarize the list concisely — no reading every item verbatim.
 
 ---
 
@@ -116,6 +151,30 @@ Wrong: "I will now retrieve the latest global news articles from the news tool."
 
 Right: "Markets were pretty healthy today — nothing too wild."
 Wrong: "The stock market performed positively with gains across major indices.
+
+---
+
+### add_reminder / list_reminders / clear_reminders — Session Memory
+add_reminder saves a note for the current session.
+list_reminders recalls all saved notes.
+clear_reminders wipes the slate.
+
+Trigger phrases:
+- "Remember that…" / "Note this…" / "Don't forget…" / "What did I tell you?" / "My notes"
+
+Behavior:
+- Confirm saves briefly: "Got it. Noted."
+- When listing, summarize — don't read them verbatim robotically.
+
+### calculate — Math
+Evaluates any arithmetic expression safely: +, -, *, /, **, sqrt(), sin(), cos(), log(), pi, e…
+
+Trigger phrases:
+- "What's [math]?" / "Calculate…" / "How much is…" / any numerical question
+
+Behavior:
+- Call silently, speak result naturally.
+- Example: "That comes out to 1,048,576, boss."
 
 ---
 

--- a/friday/config.py
+++ b/friday/config.py
@@ -13,9 +13,13 @@ class Config:
     SERVER_NAME: str = os.getenv("SERVER_NAME", "Friday")
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
 
-    # External API keys (add as needed)
+    # External API keys
     OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
     SEARCH_API_KEY: str = os.getenv("SEARCH_API_KEY", "")
+
+    # Ollama (local LLM — no API key needed)
+    OLLAMA_BASE_URL: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+    OLLAMA_MODEL: str = os.getenv("OLLAMA_MODEL", "llama3.2")
 
 
 config = Config()

--- a/friday/prompts/templates.py
+++ b/friday/prompts/templates.py
@@ -1,5 +1,6 @@
 """
-Reusable prompt templates registered with the MCP server.
+Reusable MCP prompt templates registered with the server.
+Written in F.R.I.D.A.Y.'s voice — concise, direct, intelligent.
 """
 
 
@@ -7,13 +8,38 @@ def register(mcp):
 
     @mcp.prompt()
     def summarize(text: str) -> str:
-        """Prompt to summarize a block of text."""
-        return f"Summarize the following text concisely:\n\n{text}"
+        """Summarize a block of text in FRIDAY's concise briefing style."""
+        return (
+            "You are F.R.I.D.A.Y., Tony Stark's AI. Summarize the following in 3–5 sentences "
+            "max, as if briefing your boss. Hit the key points only. No fluff.\n\n"
+            f"{text}"
+        )
 
     @mcp.prompt()
     def explain_code(code: str, language: str = "Python") -> str:
-        """Prompt to explain a block of code."""
+        """Explain code plainly, as FRIDAY would brief a non-technical exec."""
         return (
-            f"Explain the following {language} code in plain English, "
-            f"step by step:\n\n```{language.lower()}\n{code}\n```"
+            f"You are F.R.I.D.A.Y. Explain this {language} code in plain English, "
+            "as if briefing someone who is brilliant but not a programmer. "
+            "Be concise — one sentence per logical block.\n\n"
+            f"```{language.lower()}\n{code}\n```"
+        )
+
+    @mcp.prompt()
+    def draft_email(context: str, tone: str = "professional") -> str:
+        """Draft a short email from a brief description of the situation."""
+        return (
+            f"You are F.R.I.D.A.Y. Draft a {tone} email based on this context:\n\n"
+            f"{context}\n\n"
+            "Keep it under 150 words. Subject line first, then body. No filler phrases."
+        )
+
+    @mcp.prompt()
+    def threat_assessment(situation: str) -> str:
+        """Analyze a situation and return a structured risk assessment."""
+        return (
+            "You are F.R.I.D.A.Y. running a threat assessment. Analyze the situation below "
+            "and return: (1) Risk level (LOW / MEDIUM / HIGH / CRITICAL), "
+            "(2) Key risks in 2–3 bullet points, (3) Recommended action in one sentence.\n\n"
+            f"SITUATION: {situation}"
         )

--- a/friday/resources/data.py
+++ b/friday/resources/data.py
@@ -1,15 +1,42 @@
 """
-Data resources — expose static content or dynamic data via MCP resources.
+MCP Resources — dynamic data exposed to connected clients.
 """
+
+import platform
+from datetime import datetime, timezone
+
+
+_TOOL_MANIFEST = {
+    "web": ["get_world_news", "search_web", "fetch_url", "open_world_monitor"],
+    "system": ["get_current_time", "get_system_info", "get_system_diagnostics"],
+    "weather": ["get_weather"],
+    "finance": ["get_stock_price", "get_market_overview"],
+    "tickets": ["create_ticket", "list_tickets"],
+    "reminders": ["add_reminder", "list_reminders", "clear_reminders"],
+    "utils": ["calculate", "format_json", "word_count"],
+}
 
 
 def register(mcp):
 
     @mcp.resource("friday://info")
     def server_info() -> str:
-        """Returns basic info about this MCP server."""
+        """Returns identity and runtime info about this MCP server."""
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
         return (
-            "Friday MCP Server\n"
-            "A Tony Stark-inspired AI assistant.\n"
-            "Built with FastMCP."
+            "F.R.I.D.A.Y. MCP Server\n"
+            "Fully Responsive Intelligent Digital Assistant for You\n"
+            f"Host OS  : {platform.system()} {platform.release()}\n"
+            f"Python   : {platform.python_version()}\n"
+            f"Online at: {now}\n"
+            "Transport: SSE on port 8000"
         )
+
+    @mcp.resource("friday://tools")
+    def tool_manifest() -> dict:
+        """Returns the full map of available tool modules and their tool names."""
+        total = sum(len(v) for v in _TOOL_MANIFEST.values())
+        return {
+            "total_tools": total,
+            "modules": _TOOL_MANIFEST,
+        }

--- a/friday/tools/__init__.py
+++ b/friday/tools/__init__.py
@@ -3,11 +3,16 @@ Tool registry — imports and registers all tool modules with the MCP server.
 Add new tool modules here as you build them.
 """
 
-from friday.tools import web, system, utils
+from friday.tools import calculator, finance, reminders, system, tickets, utils, weather, web
 
 
 def register_all_tools(mcp):
     """Register all tool groups onto the MCP server instance."""
     web.register(mcp)
     system.register(mcp)
+    weather.register(mcp)
+    finance.register(mcp)
+    tickets.register(mcp)
+    reminders.register(mcp)
+    calculator.register(mcp)
     utils.register(mcp)

--- a/friday/tools/calculator.py
+++ b/friday/tools/calculator.py
@@ -1,0 +1,66 @@
+"""
+Calculator tool — safe arithmetic evaluation using Python's ast module.
+No exec/eval with builtins; only whitelisted math operations are allowed.
+"""
+
+import ast
+import math
+import operator
+
+# Whitelisted operators
+_OPS: dict = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.Mod: operator.mod,
+    ast.FloorDiv: operator.floordiv,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+# Whitelisted math functions
+_FUNCS: dict = {
+    name: getattr(math, name)
+    for name in ("sqrt", "log", "log10", "sin", "cos", "tan", "ceil", "floor", "fabs")
+}
+_CONSTS: dict = {"pi": math.pi, "e": math.e, "tau": math.tau, "inf": math.inf}
+
+
+def _eval_node(node: ast.AST) -> float:
+    """Recursively evaluate a whitelisted AST node."""
+    match node:
+        case ast.Constant(value=v) if isinstance(v, (int, float)):
+            return v
+        case ast.Name(id=name) if name in _CONSTS:
+            return _CONSTS[name]
+        case ast.BinOp(left=l, op=op, right=r) if type(op) in _OPS:
+            return _OPS[type(op)](_eval_node(l), _eval_node(r))
+        case ast.UnaryOp(op=op, operand=o) if type(op) in _OPS:
+            return _OPS[type(op)](_eval_node(o))
+        case ast.Call(func=ast.Name(id=fn), args=args) if fn in _FUNCS:
+            return _FUNCS[fn](*[_eval_node(a) for a in args])
+        case _:
+            raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+
+def register(mcp):
+
+    @mcp.tool()
+    def calculate(expression: str) -> str:
+        """
+        Evaluate a mathematical expression and return the result.
+        Supports +, -, *, /, **, %, sqrt(), sin(), cos(), log(), pi, e, etc.
+        Use when the boss asks for a calculation or quick math.
+        Examples: '2 ** 10', 'sqrt(144)', 'sin(pi / 2)', '(100 * 1.08) ** 3'
+        """
+        try:
+            tree = ast.parse(expression.strip(), mode="eval")
+            result = _eval_node(tree.body)
+            formatted = f"{result:.6g}"  # up to 6 sig figs, drops trailing zeros
+            return f"{expression} = {formatted}"
+        except ZeroDivisionError:
+            return "Division by zero, sir. Check your denominator."
+        except Exception as exc:
+            return f"Can't evaluate that expression: {exc}"

--- a/friday/tools/finance.py
+++ b/friday/tools/finance.py
@@ -1,0 +1,68 @@
+"""
+Finance tools — real-time stock quotes via Yahoo Finance (no API key required).
+"""
+
+import httpx
+
+_YAHOO_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+_HEADERS = {"User-Agent": "Mozilla/5.0 (Friday-AI/2.0)"}
+
+
+def _fmt_quote(q: dict) -> str:
+    """Format a Yahoo Finance quote dict into a spoken FRIDAY-style sentence."""
+    ticker = q.get("symbol", "?")
+    name = q.get("longName") or q.get("shortName") or ticker
+    price = q.get("regularMarketPrice")
+    change = q.get("regularMarketChange", 0.0)
+    pct = q.get("regularMarketChangePercent", 0.0)
+    mktcap = q.get("marketCap")
+
+    direction = "up" if change >= 0 else "down"
+    cap_str = ""
+    if mktcap:
+        cap_str = f" Market cap ${mktcap / 1e9:.1f}B." if mktcap >= 1e9 else ""
+
+    return (
+        f"{name} ({ticker}) is at ${price:.2f}, "
+        f"{direction} {abs(change):.2f} ({abs(pct):.2f}%) today.{cap_str}"
+    )
+
+
+def register(mcp):
+
+    @mcp.tool()
+    async def get_stock_price(ticker: str) -> str:
+        """
+        Get the latest stock price and daily change for a ticker symbol.
+        Examples: AAPL, TSLA, NVDA, GOOGL, AMZN, MSFT, ^DJI (Dow Jones).
+        Use when the boss asks about specific stocks or market indices.
+        """
+        async with httpx.AsyncClient(timeout=8, headers=_HEADERS) as client:
+            resp = await client.get(_YAHOO_URL, params={"symbols": ticker.upper()})
+            resp.raise_for_status()
+            quotes = resp.json().get("quoteResponse", {}).get("result", [])
+
+        if not quotes:
+            return f"Couldn't pull a quote for '{ticker}', sir. Double-check that ticker."
+
+        return _fmt_quote(quotes[0])
+
+    @mcp.tool()
+    async def get_market_overview() -> str:
+        """
+        Get a quick snapshot of major US market indices: S&P 500, Dow Jones, NASDAQ.
+        Use when the boss asks for a market overview or 'how are the markets doing'.
+        """
+        symbols = "^GSPC,^DJI,^IXIC"
+        async with httpx.AsyncClient(timeout=8, headers=_HEADERS) as client:
+            resp = await client.get(_YAHOO_URL, params={"symbols": symbols})
+            resp.raise_for_status()
+            quotes = resp.json().get("quoteResponse", {}).get("result", [])
+
+        if not quotes:
+            return "Market data is down, sir. Feeds are unresponsive."
+
+        lines = ["### MARKET SNAPSHOT"]
+        for q in quotes:
+            lines.append(_fmt_quote(q))
+        return "\n".join(lines)

--- a/friday/tools/reminders.py
+++ b/friday/tools/reminders.py
@@ -1,17 +1,61 @@
 """
-Reminders tool — lightweight in-memory note store for the current session.
-Notes survive as long as the MCP server process is running.
+Reminders tool — session notes with cross-session persistence.
+
+Notes are kept in memory for fast access and mirrored to
+~/.friday/reminders.json so they survive MCP server restarts and reboots.
+If the disk write fails (permissions, full disk), reminders still work in
+memory — the store is best-effort, never blocks the user.
 """
 
+import json
+import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
-# Module-level store: list of {id, text, created_at}
+logger = logging.getLogger(__name__)
+
+# WHY Path.home(): cross-platform (works on Windows/WSL/Linux/macOS without
+# path hardcoding) and predictable for the user — they know where their notes
+# live if they ever want to back them up or wipe them manually.
+_STORE_PATH = Path.home() / ".friday" / "reminders.json"
+
 _store: list[dict] = []
 _next_id: int = 1
+_loaded: bool = False
 
 
 def _ts() -> str:
     return datetime.now(timezone.utc).strftime("%H:%M UTC")
+
+
+def _load_once() -> None:
+    """Populate _store from disk on first access. Idempotent."""
+    global _store, _next_id, _loaded
+    if _loaded:
+        return
+    _loaded = True
+    if not _STORE_PATH.exists():
+        return
+    try:
+        data = json.loads(_STORE_PATH.read_text(encoding="utf-8"))
+        _store = data.get("reminders", [])
+        _next_id = data.get("next_id", len(_store) + 1)
+        logger.info("loaded %d reminders from %s", len(_store), _STORE_PATH)
+    except (json.JSONDecodeError, OSError) as exc:
+        # Corrupt or unreadable file — keep empty store, log but don't crash.
+        logger.warning("could not load reminders from %s: %s", _STORE_PATH, exc)
+
+
+def _persist() -> None:
+    """Flush _store to disk. Never raises — persistence is best-effort."""
+    try:
+        _STORE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _STORE_PATH.write_text(
+            json.dumps({"reminders": _store, "next_id": _next_id}, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning("could not persist reminders to %s: %s", _STORE_PATH, exc)
 
 
 def register(mcp):
@@ -19,24 +63,28 @@ def register(mcp):
     @mcp.tool()
     def add_reminder(text: str) -> str:
         """
-        Save a note or reminder for the current session.
+        Save a note or reminder. Notes persist across sessions at
+        ~/.friday/reminders.json — the boss can rely on them across restarts.
         Use when the boss says 'remember that', 'note this', 'remind me', etc.
         """
         global _next_id
+        _load_once()
         _store.append({"id": _next_id, "text": text, "created_at": _ts()})
         _next_id += 1
+        _persist()
         return f"Noted, boss. I'll keep that in mind: '{text}'"
 
     @mcp.tool()
     def list_reminders() -> str:
         """
-        Recall all notes saved this session.
+        Recall all saved notes (including those from previous sessions).
         Use when the boss asks 'what did I tell you?', 'any notes?', 'what am I remembering?'.
         """
+        _load_once()
         if not _store:
             return "Nothing on the mental stack, sir. Clean slate."
 
-        lines = [f"### SESSION NOTES ({len(_store)})"]
+        lines = [f"### NOTES ({len(_store)})"]
         for r in _store:
             lines.append(f"[{r['id']}] {r['text']}  — saved at {r['created_at']}")
         return "\n".join(lines)
@@ -44,9 +92,11 @@ def register(mcp):
     @mcp.tool()
     def clear_reminders() -> str:
         """
-        Wipe all session notes.
+        Wipe all notes, including persisted ones on disk.
         Use when the boss says 'clear my notes', 'forget that', 'wipe the slate'.
         """
+        _load_once()
         count = len(_store)
         _store.clear()
+        _persist()
         return f"Done — cleared {count} note{'s' if count != 1 else ''}, sir."

--- a/friday/tools/reminders.py
+++ b/friday/tools/reminders.py
@@ -1,0 +1,52 @@
+"""
+Reminders tool — lightweight in-memory note store for the current session.
+Notes survive as long as the MCP server process is running.
+"""
+
+from datetime import datetime, timezone
+
+# Module-level store: list of {id, text, created_at}
+_store: list[dict] = []
+_next_id: int = 1
+
+
+def _ts() -> str:
+    return datetime.now(timezone.utc).strftime("%H:%M UTC")
+
+
+def register(mcp):
+
+    @mcp.tool()
+    def add_reminder(text: str) -> str:
+        """
+        Save a note or reminder for the current session.
+        Use when the boss says 'remember that', 'note this', 'remind me', etc.
+        """
+        global _next_id
+        _store.append({"id": _next_id, "text": text, "created_at": _ts()})
+        _next_id += 1
+        return f"Noted, boss. I'll keep that in mind: '{text}'"
+
+    @mcp.tool()
+    def list_reminders() -> str:
+        """
+        Recall all notes saved this session.
+        Use when the boss asks 'what did I tell you?', 'any notes?', 'what am I remembering?'.
+        """
+        if not _store:
+            return "Nothing on the mental stack, sir. Clean slate."
+
+        lines = [f"### SESSION NOTES ({len(_store)})"]
+        for r in _store:
+            lines.append(f"[{r['id']}] {r['text']}  — saved at {r['created_at']}")
+        return "\n".join(lines)
+
+    @mcp.tool()
+    def clear_reminders() -> str:
+        """
+        Wipe all session notes.
+        Use when the boss says 'clear my notes', 'forget that', 'wipe the slate'.
+        """
+        count = len(_store)
+        _store.clear()
+        return f"Done — cleared {count} note{'s' if count != 1 else ''}, sir."

--- a/friday/tools/system.py
+++ b/friday/tools/system.py
@@ -1,9 +1,16 @@
 """
-System tools — time, environment info, shell commands, etc.
+System tools — time, host info, CPU/RAM/battery diagnostics.
+Requires psutil (listed in pyproject.toml dependencies).
 """
 
 import datetime
 import platform
+
+try:
+    import psutil
+    _PSUTIL = True
+except ImportError:
+    _PSUTIL = False
 
 
 def register(mcp):
@@ -22,3 +29,29 @@ def register(mcp):
             "machine": platform.machine(),
             "python_version": platform.python_version(),
         }
+
+    @mcp.tool()
+    def get_system_diagnostics() -> dict:
+        """
+        Return live CPU usage, RAM usage, and battery status.
+        Use when the boss asks about system health, performance, or power.
+        """
+        if not _PSUTIL:
+            return {"error": "psutil not installed — run `pip install psutil`"}
+
+        mem = psutil.virtual_memory()
+        cpu = psutil.cpu_percent(interval=0.5)
+        battery = psutil.sensors_battery()
+
+        result = {
+            "cpu_percent": cpu,
+            "ram_used_gb": round(mem.used / 1e9, 2),
+            "ram_total_gb": round(mem.total / 1e9, 2),
+            "ram_percent": mem.percent,
+        }
+
+        if battery:
+            result["battery_percent"] = battery.percent
+            result["battery_plugged_in"] = battery.power_plugged
+
+        return result

--- a/friday/tools/tickets.py
+++ b/friday/tools/tickets.py
@@ -1,0 +1,83 @@
+"""
+Ticket tools — create and list tasks via Supabase REST API.
+Gracefully no-ops when SUPABASE_URL / SUPABASE_API_KEY are not configured.
+"""
+
+import os
+from datetime import datetime, timezone
+
+import httpx
+
+
+def _base_url() -> str:
+    return os.getenv("SUPABASE_URL", "").rstrip("/")
+
+
+def _headers() -> dict:
+    key = os.getenv("SUPABASE_API_KEY", "")
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+    }
+
+
+def _is_configured() -> bool:
+    return bool(_base_url() and os.getenv("SUPABASE_API_KEY"))
+
+
+def register(mcp):
+
+    @mcp.tool()
+    async def create_ticket(title: str, description: str = "", priority: str = "medium") -> str:
+        """
+        Log a new task or ticket into the Supabase ticketing system.
+        Priority options: low | medium | high.
+        Use when the boss asks to note something, create a task, or log an issue.
+        """
+        if not _is_configured():
+            return "Ticketing system offline — Supabase credentials not set, sir."
+
+        payload = {
+            "title": title,
+            "description": description,
+            "priority": priority,
+            "status": "open",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        async with httpx.AsyncClient(timeout=8) as client:
+            resp = await client.post(
+                f"{_base_url()}/tickets", json=payload, headers=_headers()
+            )
+            resp.raise_for_status()
+
+        return f"Ticket logged: '{title}' — {priority} priority. On your list, boss."
+
+    @mcp.tool()
+    async def list_tickets(status: str = "open") -> str:
+        """
+        Retrieve tasks from the Supabase ticketing system.
+        Status: open | closed | all.
+        Use when the boss asks what's on the list, open tasks, or pending items.
+        """
+        if not _is_configured():
+            return "Ticketing system offline — Supabase credentials not set, sir."
+
+        params = {} if status == "all" else {"status": f"eq.{status}"}
+        async with httpx.AsyncClient(timeout=8) as client:
+            resp = await client.get(
+                f"{_base_url()}/tickets", params=params, headers=_headers()
+            )
+            resp.raise_for_status()
+            tickets = resp.json()
+
+        if not tickets:
+            return f"No {status} tickets, sir. Clean slate."
+
+        lines = [f"### {status.upper()} TICKETS ({len(tickets)})"]
+        for t in tickets[:10]:
+            pri = t.get("priority", "?").upper()
+            title = t.get("title", "Untitled")
+            lines.append(f"- [{pri}] {title}")
+        return "\n".join(lines)

--- a/friday/tools/weather.py
+++ b/friday/tools/weather.py
@@ -1,0 +1,64 @@
+"""
+Weather tools — current conditions via Open-Meteo (free, no API key required).
+Geocoding via the Open-Meteo geocoding API.
+"""
+
+import httpx
+
+GEO_URL = "https://geocoding-api.open-meteo.com/v1/search"
+WEATHER_URL = "https://api.open-meteo.com/v1/forecast"
+
+# WMO Weather Interpretation Codes → human-readable labels
+_WMO = {
+    0: "clear skies", 1: "mainly clear", 2: "partly cloudy", 3: "overcast",
+    45: "foggy", 48: "freezing fog",
+    51: "light drizzle", 53: "drizzle", 55: "heavy drizzle",
+    61: "light rain", 63: "rain", 65: "heavy rain",
+    71: "light snow", 73: "snow", 75: "heavy snow", 77: "snow grains",
+    80: "rain showers", 81: "heavy rain showers", 82: "violent rain showers",
+    85: "snow showers", 86: "heavy snow showers",
+    95: "thunderstorm", 96: "thunderstorm with hail", 99: "severe thunderstorm",
+}
+
+
+async def _geocode(client: httpx.AsyncClient, city: str) -> dict | None:
+    """Resolve city name to lat/lon via Open-Meteo geocoding."""
+    r = await client.get(GEO_URL, params={"name": city, "count": 1, "format": "json"})
+    r.raise_for_status()
+    results = r.json().get("results")
+    return results[0] if results else None
+
+
+def register(mcp):
+
+    @mcp.tool()
+    async def get_weather(city: str) -> str:
+        """
+        Get current weather conditions for any city on Earth.
+        Use when the boss asks about weather, temperature, or conditions in a location.
+        """
+        async with httpx.AsyncClient(timeout=8) as client:
+            loc = await _geocode(client, city)
+            if not loc:
+                return f"Can't locate '{city}' on the map, sir."
+
+            r = await client.get(WEATHER_URL, params={
+                "latitude": loc["latitude"],
+                "longitude": loc["longitude"],
+                "current_weather": "true",
+                "hourly": "relative_humidity_2m",
+                "forecast_days": 1,
+                "timezone": "auto",
+            })
+            r.raise_for_status()
+            data = r.json()
+
+        cw = data["current_weather"]
+        humidity = data["hourly"]["relative_humidity_2m"][0]
+        condition = _WMO.get(int(cw["weathercode"]), "unknown conditions")
+        name, country = loc["name"], loc.get("country", "")
+
+        return (
+            f"{name}, {country}: {cw['temperature']}°C, {condition}. "
+            f"Wind {cw['windspeed']} km/h. Humidity {humidity}%."
+        )

--- a/friday/tools/web.py
+++ b/friday/tools/web.py
@@ -83,16 +83,53 @@ def register(mcp):
 
     @mcp.tool()
     async def search_web(query: str) -> str:
-        """Search the web for a given query and return a summary of results."""
-        return f"[stub] Search results for: {query}"
+        """Search the web for a query using DuckDuckGo and return a results summary."""
+        ddg_url = "https://api.duckduckgo.com/"
+        params = {"q": query, "format": "json", "no_html": "1", "skip_disambig": "1"}
+
+        async with httpx.AsyncClient(timeout=8) as client:
+            resp = await client.get(ddg_url, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+
+        lines = [f"### Web results for: {query}\n"]
+
+        if abstract := data.get("AbstractText"):
+            lines.append(f"**Summary:** {abstract}")
+            if src := data.get("AbstractSource"):
+                lines.append(f"Source: {src} — {data.get('AbstractURL', '')}\n")
+
+        if answer := data.get("Answer"):
+            lines.append(f"**Direct answer:** {answer}\n")
+
+        topics = data.get("RelatedTopics", [])[:5]
+        if topics:
+            lines.append("**Related:**")
+            for t in topics:
+                if text := t.get("Text"):
+                    lines.append(f"- {text}")
+
+        if len(lines) == 1:
+            return f"No clear results for '{query}', sir. Try rephrasing."
+
+        return "\n".join(lines)
 
     @mcp.tool()
     async def fetch_url(url: str) -> str:
-        """Fetch the raw text content of a URL."""
-        async with httpx.AsyncClient(follow_redirects=True, timeout=10) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.text[:4000]
+        """
+        Fetch and return readable plain text from a URL, stripping all HTML tags.
+        Use when the boss asks to read a specific article or page.
+        """
+        headers = {"User-Agent": "Mozilla/5.0 (Friday-AI/2.0)"}
+        async with httpx.AsyncClient(follow_redirects=True, timeout=10, headers=headers) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+
+        # Strip tags, collapse whitespace, cap length
+        text = re.sub(r"<[^>]+>", " ", resp.text)
+        text = re.sub(r"[ \t]{2,}", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text).strip()
+        return text[:3000] + ("\n\n[truncated]" if len(text) > 3000 else "")
     
     @mcp.tool()
     async def open_world_monitor() -> str:

--- a/friday_mcp.py
+++ b/friday_mcp.py
@@ -1,0 +1,111 @@
+"""
+MCP tool bridge for FRIDAY's REPL / voice modes.
+
+Connects to the fastmcp server over SSE, lists tools, and wraps each as a
+LiveKit `RawFunctionTool` so the LLM receives a proper function-calling
+schema.  Actual dispatch is manual (via `dispatch()`), because the REPL
+drives `llm.chat()` directly rather than going through `AgentSession`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastmcp import Client
+from livekit.agents.llm import function_tool
+
+log = logging.getLogger("friday.mcp")
+
+
+async def open_mcp(url: str, *, allow: list[str] | None = None):
+    """
+    Connect to the MCP server and return (client, tools, dispatch).
+
+    - `client` is an already-entered fastmcp.Client (caller must `await client.close()`).
+    - `tools` is a list of LiveKit RawFunctionTool objects, ready to pass to llm.chat().
+    - `dispatch(name, args_json)` returns the tool result as a string.
+    - `allow` optionally restricts tool exposure to the LLM.  Tools outside the
+      allowlist are still dispatchable (if the LLM names them), just not offered.
+      Default: expose everything.  WHY: prefilling 18 tool schemas on a 7B CPU
+      model costs ~170s; trimming to 6 brings that to ~60s for a responsive demo.
+    """
+    client = Client(url)
+    await client.__aenter__()  # keep open for the life of the REPL
+
+    mcp_tools = await client.list_tools()
+    log.info("connected to MCP: %d tools", len(mcp_tools))
+
+    if allow:
+        allow_set = set(allow)
+        exposed = [t for t in mcp_tools if t.name in allow_set]
+        missing = allow_set - {t.name for t in mcp_tools}
+        if missing:
+            log.warning("allowlist references unknown tools: %s", sorted(missing))
+        log.info("exposing %d/%d tools to the LLM", len(exposed), len(mcp_tools))
+    else:
+        exposed = mcp_tools
+
+    lk_tools = [_wrap(t) for t in exposed]
+
+    async def dispatch(name: str, args_json: str) -> str:
+        # OpenAI streams arguments as a JSON string — parse to kwargs.
+        try:
+            kwargs = json.loads(args_json) if args_json else {}
+        except json.JSONDecodeError as exc:
+            return f"[tool-call error: bad JSON args: {exc}]"
+
+        try:
+            result = await client.call_tool(name, kwargs)
+        except Exception as exc:  # surface to the model so it can retry
+            return f"[tool '{name}' failed: {exc}]"
+
+        return _format_result(result)
+
+    return client, lk_tools, dispatch
+
+
+def _wrap(mcp_tool: Any):
+    """Convert one MCP Tool → LiveKit RawFunctionTool."""
+    schema = {
+        "name": mcp_tool.name,
+        "description": (mcp_tool.description or "").strip() or mcp_tool.name,
+        "parameters": mcp_tool.inputSchema or {"type": "object", "properties": {}},
+    }
+
+    # Wrapper body is never called — we dispatch manually in _chat_with_tools.
+    # LiveKit's raw_schema path only needs the schema; the function is a stub.
+    async def _stub(**_kwargs: Any) -> str:
+        return "[dispatched manually]"
+
+    _stub.__name__ = mcp_tool.name
+    return function_tool(_stub, raw_schema=schema)
+
+
+def _format_result(result: Any) -> str:
+    """
+    fastmcp.call_tool returns a CallToolResult with three payload channels:
+      - structured_content: already-parsed JSON dict (cleanest for the LLM)
+      - content: list of TextContent blocks (human-readable fallback)
+      - data:   dynamic dataclass wrapper (looks pretty but has no model_dump)
+    Prefer structured_content; fall back to concatenated text.
+    """
+    structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        # Many MCP tools return {"result": <actual>}; unwrap that one level
+        # so the LLM sees the value directly instead of {"result": "..."}.
+        if isinstance(structured, dict) and set(structured.keys()) == {"result"}:
+            structured = structured["result"]
+        try:
+            return json.dumps(structured, default=str)[:4000]
+        except (TypeError, ValueError):
+            pass
+
+    content = getattr(result, "content", None)
+    if content:
+        parts = [text for block in content if (text := getattr(block, "text", None))]
+        if parts:
+            return "\n".join(parts)[:4000]
+
+    return str(result)[:4000]

--- a/friday_stt.py
+++ b/friday_stt.py
@@ -1,0 +1,102 @@
+"""
+Speech-to-text for FRIDAY's fullvoice mode.
+
+Uses faster-whisper with a small English model (tiny.en by default ~75MB)
+and sounddevice for mic capture.  Push-to-talk UX: the caller drives
+record_until_enter() from the main thread, which returns a numpy float32
+mono buffer; transcribe() feeds that to Whisper.
+
+Model is loaded lazily and cached — first call downloads ~75MB once.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from typing import Any
+
+import numpy as np
+import sounddevice as sd
+from faster_whisper import WhisperModel
+
+log = logging.getLogger("friday.stt")
+
+SAMPLE_RATE = 16000  # Whisper expects 16kHz
+CHANNELS = 1
+
+_model_cache: dict[str, WhisperModel] = {}
+
+
+def load_whisper(size: str = "tiny.en") -> WhisperModel:
+    """Load and cache a faster-whisper model.  CPU-only, int8 quant for speed."""
+    if size in _model_cache:
+        return _model_cache[size]
+    log.info("loading whisper model: %s (first run downloads ~75MB)", size)
+    model = WhisperModel(size, device="cpu", compute_type="int8")
+    _model_cache[size] = model
+    return model
+
+
+def record_until_enter() -> np.ndarray:
+    """
+    Record from the default input device until the user hits Enter.
+
+    Returns a (N,) float32 array in the range [-1, 1] at 16kHz mono.
+    Prints prompts to stdout; uses input() to gate start/stop.
+    """
+    print("[press ENTER to start recording]", flush=True)
+    try:
+        input()
+    except (EOFError, KeyboardInterrupt):
+        return np.zeros(0, dtype=np.float32)
+
+    chunks: list[np.ndarray] = []
+    stop_flag = threading.Event()
+
+    def _on_audio(indata: np.ndarray, frames: int, time_info: Any, status: Any) -> None:
+        # PortAudio thread — just append; don't do heavy work here.
+        if status:
+            log.debug("audio status: %s", status)
+        chunks.append(indata.copy().flatten())
+
+    stream = sd.InputStream(
+        samplerate=SAMPLE_RATE,
+        channels=CHANNELS,
+        dtype="float32",
+        callback=_on_audio,
+    )
+
+    print("[recording... press ENTER to stop]", flush=True)
+    with stream:
+        try:
+            input()
+        except (EOFError, KeyboardInterrupt):
+            pass
+        stop_flag.set()
+
+    if not chunks:
+        return np.zeros(0, dtype=np.float32)
+    return np.concatenate(chunks)
+
+
+def transcribe(model: WhisperModel, audio: np.ndarray) -> str:
+    """Transcribe a float32 mono 16kHz buffer; return the joined text."""
+    if audio.size == 0 or np.abs(audio).max() < 0.002:
+        return ""  # silence or empty
+    segments, _info = model.transcribe(
+        audio,
+        language="en",
+        beam_size=1,           # greedy decode — fast on CPU
+        vad_filter=True,       # skip silences
+        vad_parameters={"min_silence_duration_ms": 500},
+    )
+    return " ".join(seg.text.strip() for seg in segments).strip()
+
+
+def ensure_stdin_tty() -> bool:
+    """Return True if stdin is a terminal (PTT requires interactive input)."""
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False

--- a/main.py
+++ b/main.py
@@ -1,5 +1,69 @@
-def main():
-    print("Hello from friday-tony-stark-demo!")
+"""
+F.R.I.D.A.Y. — project status & quick-start helper.
+
+Usage:
+  python main.py           # print project status
+  python main.py server    # alias: start the MCP server
+  python main.py voice     # alias: start the voice agent
+"""
+
+import sys
+import subprocess
+
+
+_BANNER = r"""
+  _____  _____  _____  _____    _    __   __
+ |  ___||  _  ||_   _||  _  |  / \  \ \ / /
+ | |_   | |_| |  | |  | | | | / _ \  \ V /
+ |  _|  |    /   | |  | |_| |/ ___ \  | |
+ |_|    |_|\_\   |_|  |_____/_/   \_\ |_|
+
+ Fully Responsive Intelligent Digital Assistant for You
+"""
+
+_STATUS = """
+ COMPONENTS
+ ──────────────────────────────────────
+  MCP Server    →  uv run friday          (SSE on :8000)
+  Voice Agent   →  uv run friday_voice    (LiveKit dev mode)
+
+ TOOLS ONLINE
+ ──────────────────────────────────────
+  web       get_world_news · search_web · fetch_url · open_world_monitor
+  system    get_current_time · get_system_info · get_system_diagnostics
+  weather   get_weather
+  finance   get_stock_price · get_market_overview
+  tickets   create_ticket · list_tickets
+  reminders add_reminder · list_reminders · clear_reminders
+  utils     calculate · format_json · word_count
+
+ QUICK START
+ ──────────────────────────────────────
+  1. cp .env.example .env  →  fill in API keys
+  2. uv sync               →  install deps
+  3. uv run friday         →  start MCP server  (terminal 1)
+  4. uv run friday_voice   →  start voice agent (terminal 2)
+  5. Open https://agents-playground.livekit.io and connect
+"""
+
+
+def _run(cmd: list[str]) -> None:
+    try:
+        subprocess.run(cmd, check=True)
+    except KeyboardInterrupt:
+        pass
+
+
+def main() -> None:
+    arg = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    if arg == "server":
+        _run(["uv", "run", "friday"])
+    elif arg == "voice":
+        _run(["uv", "run", "friday_voice"])
+    else:
+        print(_BANNER)
+        print(_STATUS)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 """
-F.R.I.D.A.Y. — project status & quick-start helper.
+F.R.I.D.A.Y. -- project status & quick-start helper.
 
 Usage:
   python main.py           # print project status
@@ -23,26 +23,26 @@ _BANNER = r"""
 
 _STATUS = """
  COMPONENTS
- ──────────────────────────────────────
-  MCP Server    →  uv run friday          (SSE on :8000)
-  Voice Agent   →  uv run friday_voice    (LiveKit dev mode)
+ --------------------------------------
+  MCP Server  :  uv run friday          (SSE on :8000)
+  Voice Agent :  uv run friday_voice    (LiveKit dev mode)
 
  TOOLS ONLINE
- ──────────────────────────────────────
-  web       get_world_news · search_web · fetch_url · open_world_monitor
-  system    get_current_time · get_system_info · get_system_diagnostics
+ --------------------------------------
+  web       get_world_news, search_web, fetch_url, open_world_monitor
+  system    get_current_time, get_system_info, get_system_diagnostics
   weather   get_weather
-  finance   get_stock_price · get_market_overview
-  tickets   create_ticket · list_tickets
-  reminders add_reminder · list_reminders · clear_reminders
-  utils     calculate · format_json · word_count
+  finance   get_stock_price, get_market_overview
+  tickets   create_ticket, list_tickets
+  reminders add_reminder, list_reminders, clear_reminders
+  utils     calculate, format_json, word_count
 
  QUICK START
- ──────────────────────────────────────
-  1. cp .env.example .env  →  fill in API keys
-  2. uv sync               →  install deps
-  3. uv run friday         →  start MCP server  (terminal 1)
-  4. uv run friday_voice   →  start voice agent (terminal 2)
+ --------------------------------------
+  1. cp .env.example .env  ->  fill in API keys
+  2. uv sync               ->  install deps
+  3. uv run friday         ->  start MCP server  (terminal 1)
+  4. uv run friday_voice   ->  start voice agent (terminal 2)
   5. Open https://agents-playground.livekit.io and connect
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx",
     "livekit-agents[deepgram,groq,openai,sarvam,silero]>=1.5.1",
     "livekit-plugins-google>=1.5.1",
+    "psutil>=5.9",
     "python-dotenv",
 ]
 
@@ -21,4 +22,5 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["server.py"]
+# Include both top-level entry-point modules and the friday package
+packages = ["friday", "server.py", "agent_friday.py", "main.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "livekit-plugins-google>=1.5.1",
     "psutil>=5.9",
     "python-dotenv",
+    # fullvoice mode (mic -> STT -> LLM -> TTS) — see agent_friday.py `fullvoice`.
+    # tiny.en model auto-downloads to HF cache on first use (~75MB).
+    "faster-whisper>=1.0",
+    "sounddevice>=0.4",
+    "numpy>=1.24",
 ]
 # Note: `agent_friday.py voice` uses Windows built-in SAPI via a PowerShell
 # subprocess (System.Speech.Synthesis).  No extra Python dep required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "psutil>=5.9",
     "python-dotenv",
 ]
+# Note: `agent_friday.py voice` uses Windows built-in SAPI via a PowerShell
+# subprocess (System.Speech.Synthesis).  No extra Python dep required.
 
 [project.scripts]
 friday = "server:main"

--- a/test_reminders_persistence.py
+++ b/test_reminders_persistence.py
@@ -1,0 +1,107 @@
+"""
+Smoke test for persistent reminders — proves the JSON roundtrip, lazy-load,
+and graceful degradation on disk failure all work without running the MCP
+server.
+
+Run: uv run python test_reminders_persistence.py
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _reload_module():
+    """Fresh module state for each test — reminders.py has module-level globals."""
+    import importlib
+    import friday.tools.reminders as r
+    importlib.reload(r)
+    return r
+
+
+def test_fresh_install_has_empty_store():
+    """No reminders.json → empty store, next_id=1, no crash."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch("pathlib.Path.home", return_value=Path(tmp)):
+            r = _reload_module()
+            r._load_once()
+            assert r._store == [], f"expected empty, got {r._store}"
+            assert r._next_id == 1
+
+
+def test_persist_roundtrip():
+    """Write a reminder, reload module, verify it's still there."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch("pathlib.Path.home", return_value=Path(tmp)):
+            r = _reload_module()
+            r._load_once()
+            r._store.append({"id": 1, "text": "Mumbai time", "created_at": "11:00 UTC"})
+            r._next_id = 2
+            r._persist()
+
+            # Simulate process restart — reload module, check disk state rehydrates
+            r2 = _reload_module()
+            r2._load_once()
+            assert len(r2._store) == 1, f"expected 1 reminder, got {r2._store}"
+            assert r2._store[0]["text"] == "Mumbai time"
+            assert r2._next_id == 2
+
+
+def test_corrupt_json_does_not_crash():
+    """A malformed reminders.json should not break the tool — fall back to empty."""
+    with tempfile.TemporaryDirectory() as tmp:
+        bad = Path(tmp) / ".friday" / "reminders.json"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("{not valid json", encoding="utf-8")
+
+        with patch("pathlib.Path.home", return_value=Path(tmp)):
+            r = _reload_module()
+            r._load_once()
+            assert r._store == [], f"expected empty on corrupt, got {r._store}"
+
+
+def test_clear_persists_empty_state():
+    """Clearing reminders should wipe the disk file too, not just memory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch("pathlib.Path.home", return_value=Path(tmp)):
+            r = _reload_module()
+            r._load_once()
+            r._store.extend([{"id": 1, "text": "a"}, {"id": 2, "text": "b"}])
+            r._next_id = 3
+            r._persist()
+
+            r._store.clear()
+            r._persist()
+
+            # Reload and verify disk is empty
+            r2 = _reload_module()
+            r2._load_once()
+            assert r2._store == [], f"expected empty after clear, got {r2._store}"
+
+
+def main() -> int:
+    tests = [
+        test_fresh_install_has_empty_store,
+        test_persist_roundtrip,
+        test_corrupt_json_does_not_crash,
+        test_clear_persists_empty_state,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            print(f"  FAIL  {t.__name__}: {exc}")
+            failed += 1
+        except Exception as exc:
+            print(f"  ERROR {t.__name__}: {type(exc).__name__}: {exc}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_streaming_tts.py
+++ b/test_streaming_tts.py
@@ -1,0 +1,86 @@
+"""
+Smoke test for _speak_streaming — proves the queue/consumer + sentence-boundary
+logic works without needing Ollama, Whisper, or a real TTS daemon.
+
+Feeds synthetic token chunks into the queue exactly the way _chat_with_tools
+would during streaming, captures every "sentence" the consumer dispatches to
+the (mocked) speak(), and asserts the splitting matches expectations.
+
+Run: uv run python test_streaming_tts.py
+"""
+
+import asyncio
+import sys
+
+from agent_friday import _speak_streaming
+
+
+async def _drive(chunks: list[str]) -> list[str]:
+    """Feed chunks + None sentinel through _speak_streaming, return what was spoken."""
+    spoken: list[str] = []
+
+    async def fake_speak(text: str) -> None:
+        spoken.append(text)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    task = asyncio.create_task(_speak_streaming(queue, fake_speak))
+    for tok in chunks:
+        queue.put_nowait(tok)
+    queue.put_nowait(None)
+    await task
+    return spoken
+
+
+async def test_speaks_sentences_as_they_land():
+    got = await _drive(["It's ", "11:42 PM, ", "boss. ", "Markets ", "look fine."])
+    expected = ["It's 11:42 PM, boss.", "Markets look fine."]
+    assert got == expected, f"expected {expected}, got {got}"
+
+
+async def test_handles_tail_without_trailing_space():
+    got = await _drive(["Got it."])
+    assert got == ["Got it."], f"got {got}"
+
+
+async def test_empty_stream_speaks_nothing():
+    got = await _drive([])
+    assert got == [], f"got {got}"
+
+
+async def test_abbreviation_with_trailing_space_splits_naively():
+    # KNOWN LIMITATION: the splitter treats any ". " as a boundary, so
+    # "U.S. markets" gets split into "U.S." and "markets…".  Real-world
+    # fix would be an abbreviation dictionary; not worth it for FRIDAY's
+    # short conversational replies which are abbreviation-light.  This
+    # test pins the current behavior so regressions are visible.
+    got = await _drive(["U.S. ", "markets closed up. "])
+    assert got == ["U.S.", "markets closed up."], f"got {got}"
+
+
+async def test_multiple_sentences_in_single_chunk():
+    got = await _drive(["One. Two! Three? Four."])
+    assert got == ["One.", "Two!", "Three?", "Four."], f"got {got}"
+
+
+async def main() -> int:
+    tests = [
+        test_speaks_sentences_as_they_land,
+        test_handles_tail_without_trailing_space,
+        test_empty_stream_speaks_nothing,
+        test_abbreviation_with_trailing_space_splits_naively,
+        test_multiple_sentences_in_single_chunk,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            await t()
+            print(f"  PASS  {t.__name__}")
+        except AssertionError as exc:
+            print(f"  FAIL  {t.__name__}: {exc}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/uv.lock
+++ b/uv.lock
@@ -529,6 +529,43 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/25/41920ccee68e91cb6fa0fc9e8078ab2b7839f2c668f750dc123144cb7c6e/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f74200bab9996b14a57cf6f7cb27d0921ceedc4acc1e905598e3e85b4d75b1ec", size = 1256943, upload-time = "2026-02-04T06:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/79/22/bc81fcc9f10ba4da3ffd1a9adec15cfb73cb700b3bbe69c6c8b55d333316/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:59b427eb3ac999a746315b03a63942fddd351f511db82ba1a66880d4dea98e25", size = 11916445, upload-time = "2026-02-04T06:11:19.938Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a7/494a66bb02c7926331cadfff51d5ce81f5abfb1e8d05d7f2459082f31b48/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95f0c1051c180669d2a83a44b44b518b2d1683de125f623bbc81ad5dd6f6141c", size = 16696997, upload-time = "2026-02-04T06:11:22.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4e/b48f79fd36e5d3c7e12db383aa49814c340921a618ef7364bd0ced670644/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed92d9ab0ac6bc7005942be83d68714c80adb0897ab17f98157294ee0374347", size = 38836379, upload-time = "2026-02-04T06:11:26.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/8c01ac52e1f26fc4dbe985a35222ae7cd365bbf7ee5db5fd5545d8926f91/ctranslate2-4.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:67d9ad9b69933fbfeee7dcec899b2cd9341d5dca4fdfb53e8ba8c109dc332ee1", size = 18843315, upload-time = "2026-02-04T06:11:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0f/581de94b64c5f2327a736270bc7e7a5f8fe5cf1ed56a2203b52de4d8986a/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c0cbd46a23b8dc37ccdbd9b447cb5f7fadc361c90e9df17d82ca84b1f019986", size = 1257089, upload-time = "2026-02-04T06:11:32.442Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e9/d55b0e436362f9fe26bd98fefd2dd5d81926121f1d7f799c805e6035bb26/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5b141ddad1da5f84cf3c2a569a56227a37de649a555d376cbd9b80e8f0373dd8", size = 11918502, upload-time = "2026-02-04T06:11:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ce/9f29f0b0bb4280c2ebafb3ddb6cdff8ef1c2e185ee020c0ec0ecba7dc934/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d00a62544db4a3caaa58a3c50d39b25613c042b430053ae32384d94eb1d40990", size = 16859601, upload-time = "2026-02-04T06:11:36.227Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/86/428d270fd72117d19fb48ed3211aa8a3c8bd7577373252962cb634e0fd01/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:722b93a89647974cbd182b4c7f87fefc7794fff7fc9cbd0303b6447905cc157e", size = 38995338, upload-time = "2026-02-04T06:11:42.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f4/d23dbfb9c62cb642c114a30f05d753ba61d6ffbfd8a3a4012fe85a073bcb/ctranslate2-4.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d0f734dc3757118094663bdaaf713f5090c55c1927fb330a76bb8b84173940e8", size = 18844949, upload-time = "2026-02-04T06:11:45.436Z" },
+    { url = "https://files.pythonhosted.org/packages/34/6d/eb49ba05db286b4ea9d5d3fcf5f5cd0a9a5e218d46349618d5041001e303/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6b2abf2929756e3ec6246057b56df379995661560a2d776af05f9d97f63afcf5", size = 1256960, upload-time = "2026-02-04T06:11:47.487Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5a/b9cce7b00d89fc6fdeaf27587aa52d0597b465058563e93ff50910553bdd/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:857ef3959d6b1c40dc227c715a36db33db2d097164996d6c75b6db8e30828f52", size = 11918645, upload-time = "2026-02-04T06:11:49.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/03/c0db0a5276599fb44ceafa2f2cb1afd5628808ec406fe036060a39693680/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:393a9e7e989034660526a2c0e8bb65d1924f43d9a5c77d336494a353d16ba2a4", size = 16860452, upload-time = "2026-02-04T06:11:52.276Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/03/4e3728ce29d192ee75ed9a2d8589bf4f19edafe5bed3845187de51b179a3/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a3d0682f2b9082e31c73d75b45f16cde77355ab76d7e8356a24c3cb2480a6d3", size = 38995174, upload-time = "2026-02-04T06:11:55.477Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/15/6e8e87c6a201d69803a79ac2e29623ce7c2cc9cd1df9db99810cca714373/ctranslate2-4.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:baa6d2b10f57933d8c11791e8522659217918722d07bbef2389a443801125fe7", size = 18844953, upload-time = "2026-02-04T06:11:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/8a6b7ba18cad0c8667ee221ddab8c361cb70926440e5b8dd0e81924c28ac/ctranslate2-4.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d5dfb076566551f4959dfd0706f94c923c1931def9b7bb249a2caa6ab23353a0", size = 1257560, upload-time = "2026-02-04T06:12:00.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c2/8817ca5d6c1b175b23a12f7c8b91484652f8718a76353317e5919b038733/ctranslate2-4.7.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:eecdb4ed934b384f16e8c01b185b082d6b5ffc7dcbb0b6a6eb48cd465282d957", size = 11918995, upload-time = "2026-02-04T06:12:02.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/b8eb3acc67bbca4d9872fc9ff94db78e6167a7ba5cd932f585d1560effc7/ctranslate2-4.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1aa6796edcc3c8d163c9e39c429d50076d266d68980fed9d1b2443f617c67e9e", size = 16844162, upload-time = "2026-02-04T06:12:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/80/11/6474893b07121057035069a0a483fe1cd8c47878213f282afb4c0c6fc275/ctranslate2-4.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24c0482c51726430fb83724451921c0e539d769c8618dcfd46b1645e7f75960d", size = 38966728, upload-time = "2026-02-04T06:12:07.923Z" },
+    { url = "https://files.pythonhosted.org/packages/94/88/8fc7ff435c5e783e5fad9586d839d463e023988dbbbad949d442092d01f1/ctranslate2-4.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:76db234c0446a23d20dd8eeaa7a789cc87d1d05283f48bf3152bae9fa0a69844", size = 19100788, upload-time = "2026-02-04T06:12:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b3/f100013a76a98d64e67c721bd4559ea4eeb54be3e4ac45f4d801769899af/ctranslate2-4.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:058c9db2277dc8b19ecc86c7937628f69022f341844b9081d2ab642965d88fc6", size = 1280179, upload-time = "2026-02-04T06:12:12.596Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/b77f748015667a5e2ca54a5ee080d7016fce34314f0e8cf904784549305a/ctranslate2-4.7.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:5abcf885062c7f28a3f9a46be8d185795e8706ac6230ad086cae0bc82917df31", size = 11940166, upload-time = "2026-02-04T06:12:14.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/78/6d7fd52f646c6ba3343f71277a9bbef33734632949d1651231948b0f0359/ctranslate2-4.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9950acb04a002d5c60ae90a1ddceead1a803af1f00cadd9b1a1dc76e1f017481", size = 16849483, upload-time = "2026-02-04T06:12:17.082Z" },
+    { url = "https://files.pythonhosted.org/packages/40/27/58769ff15ac31b44205bd7a8aeca80cf7357c657ea5df1b94ce0f5c83771/ctranslate2-4.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1dcc734e92e3f1ceeaa0c42bbfd009352857be179ecd4a7ed6cccc086a202f58", size = 38949393, upload-time = "2026-02-04T06:12:21.302Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5c/9fa0ad6462b62efd0fb5ac1100eee47bc96ecc198ff4e237c731e5473616/ctranslate2-4.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dfb7657bdb7b8211c8f9ecb6f3b70bc0db0e0384d01a8b1808cb66fe7199df59", size = 19123451, upload-time = "2026-02-04T06:12:24.115Z" },
+]
+
+[[package]]
 name = "cyclopts"
 version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +651,22 @@ wheels = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "fastmcp"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -646,6 +699,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
+]
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
@@ -658,22 +720,28 @@ name = "friday-tony-stark-demo"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "faster-whisper" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "livekit-agents", extra = ["deepgram", "groq", "openai", "sarvam", "silero"] },
     { name = "livekit-plugins-google" },
+    { name = "numpy" },
     { name = "psutil" },
     { name = "python-dotenv" },
+    { name = "sounddevice" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "faster-whisper", specifier = ">=1.0" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "livekit-agents", extras = ["deepgram", "groq", "openai", "sarvam", "silero"], specifier = ">=1.5.1" },
     { name = "livekit-plugins-google", specifier = ">=1.5.1" },
+    { name = "numpy", specifier = ">=1.24" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "python-dotenv" },
+    { name = "sounddevice", specifier = ">=0.4" },
 ]
 
 [[package]]
@@ -779,6 +847,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]
@@ -961,6 +1038,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1104,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
 ]
 
 [[package]]
@@ -2670,6 +2799,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2748,6 +2886,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -662,6 +662,7 @@ dependencies = [
     { name = "httpx" },
     { name = "livekit-agents", extra = ["deepgram", "groq", "openai", "sarvam", "silero"] },
     { name = "livekit-plugins-google" },
+    { name = "psutil" },
     { name = "python-dotenv" },
 ]
 
@@ -671,6 +672,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "livekit-agents", extras = ["deepgram", "groq", "openai", "sarvam", "silero"], specifier = ">=1.5.1" },
     { name = "livekit-plugins-google", specifier = ">=1.5.1" },
+    { name = "psutil", specifier = ">=5.9" },
     { name = "python-dotenv" },
 ]
 


### PR DESCRIPTION
# FRIDAY — Tool Calling, Voice I/O, and Streaming TTS

End-to-end upgrade of the FRIDAY voice agent: the model now calls MCP tools, speaks over Windows SAPI, accepts mic input via Whisper STT, and — new — streams TTS sentence-by-sentence so the user hears the first reply ~3-5s after asking instead of waiting 15-60s.

## What's new

### Tool calling (`145c66f`, `82fb15d`)
- `friday_mcp.py` — MCP tool bridge that discovers tools from the running fastmcp server, filters by allowlist, and exposes them as LiveKit `RawFunctionTool` objects.
- `_chat_with_tools` in `agent_friday.py` — drives a tool-calling loop: streams text + tool-call deltas, dispatches tool calls through the MCP client, appends `FunctionCall`/`FunctionCallOutput` items to the chat context, re-invokes `llm.chat()`. Capped at 4 iterations.
- `FRIDAY_TOOLS` env var — CSV allowlist (default: 6 demo-critical tools to keep prefill ~60s on CPU). `FRIDAY_TOOLS=*` exposes all 18.
- Tool result formatting via `structured_content` with single-key `"result"` envelope unwrap — clean JSON, no ugly `Output(result=...)` dataclass repr.

### Text REPL mode (`5a227f8`, `6b7e6a3`)
- New `repl` subcommand bypasses LiveKit's console loop for pure text Ollama chat. Instant greeting, no mic/speaker init.
- Fixed Ollama timeout storms — 600s httpx read timeout + `APIConnectOptions(timeout=600.0)` — 7B models on CPU need it.

### Voice mode (`1cab2a3`)
- New `voice` subcommand — text-in, voice-out via a persistent Windows SAPI PowerShell daemon (amortized ~5s .NET JIT, then each utterance is one stdin line).
- Zero cloud keys required for audio.

### Full voice mode (`c1b5555`, `85b5058`, `dff3edf`)
- New `fullvoice` subcommand — mic → STT → LLM → TTS → speaker.
- `friday_stt.py` — faster-whisper `tiny.en` (int8 CPU, ~75MB), cached across turns. Two-Enter PTT gate. Silence/noise early-exit avoids feeding empty audio to Whisper.

### Prewarm & tool-call reliability (`c6404f7`)
- `_prewarm_llm` — primes Ollama's KV prefix cache with system prompt + tool schemas so the first real turn reuses ~2000-2500 tokens of prefill. Drains the stream to completion (early break caused cache-commit issues on Ollama's side).
- Ran in parallel with TTS greeting in voice mode, serial in REPL.
- Default model bumped to `qwen2.5:7b-instruct` — `llama3.2:1b` emits tool calls as free text (broken on Ollama's OpenAI-compat layer).
- Documented `get_current_time` in `SYSTEM_PROMPT` + added catch-all behavioral rule: "For ANY question requiring live data, call the tool. Never answer from training memory."

### Persistent session memory (`0bec5e0`, `ee8dcd6`)
- Reminders (`add_reminder` / `list_reminders` / `clear_reminders`) now survive MCP server restarts and reboots.
- Backed by `~/.friday/reminders.json` — lazy-loaded on first tool call, flushed after every mutation.
- Best-effort persistence: disk errors are logged but never raised; reminders still work in memory if the disk write fails.
- Corrupt JSON falls back to empty instead of crashing.
- 4 smoke tests exercise the roundtrip, fresh-install, corrupt-file, and clear paths.

### Streaming TTS (`cb0db0d`)
- New: sentence-by-sentence speech dispatch while generation continues.
- Producer/consumer pattern — `on_text` callback pushes tokens into an `asyncio.Queue`; background `_speak_streaming` task drains it, buffers until sentence boundary (`.!?` + whitespace), sends each sentence to the SAPI daemon.
- Both Ollama HTTP stream and SAPI subprocess are async I/O — they genuinely interleave at the event loop.
- Tool-call markers (`[tool: …]`) filtered from TTS queue — display-only.

## Usage

```bash
# Start MCP server (one-time)
uv run python server.py

# Pick your mode
uv run python agent_friday.py repl        # text in, text out
uv run python agent_friday.py voice       # text in, voice out
uv run python agent_friday.py fullvoice   # mic in, voice out

# Optional: expose all 18 tools (slower prefill)
FRIDAY_TOOLS=* uv run python agent_friday.py voice
```

## Testing notes

- Requires Ollama running with `qwen2.5:7b-instruct` (or set `OLLAMA_MODEL` to another tool-capable model — `qwen2.5-coder:7b`, `llama3.1:latest` also work).
- First turn on cold cache: ~60s. Subsequent turns: ~3-8s to first audible word.
- On Windows with R:\models Ollama config, mount R: before launching or Ollama will fail with `mkdir R:\models: The system cannot find the path specified`.

## Commits

```
cb0db0d feat(voice): stream TTS sentence-by-sentence as LLM generates
f469466 chore: update uv.lock for faster-whisper/sounddevice/numpy deps
c6404f7 fix(tool-calling): default qwen2.5:7b, document get_current_time, enforce live-data rule
dff3edf add STT deps for fullvoice mode
85b5058 add fullvoice subcommand — mic -> STT -> LLM -> TTS
c1b5555 add mic-based STT module for fullvoice mode
82fb15d wire MCP tool calling into REPL and voice modes
145c66f add MCP tool bridge for REPL and voice modes
1cab2a3 feat(voice): add local TTS subcommand — FRIDAY speaks her replies
5a227f8 feat(repl): add text REPL subcommand bypassing LiveKit console
6b7e6a3 fix(ollama): stop LLM timeout storms + instant greeting
35d9957 fix: replace Unicode box-drawing chars in main.py with ASCII
36330bb feat: add Ollama as a local LLM provider
```
